### PR TITLE
Add CLI setup cookbook and Podman runtime support

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,7 +1,7 @@
 # EUDIPLO CLI
 
 The EUDIPLO CLI provides deployment-neutral commands for inspecting an EUDIPLO
-instance and deployment-driver commands for local Docker Compose demos.
+instance and deployment-driver commands for local Compose demos.
 
 For installation, command reference, configuration validation, standalone
 releases, and local development, see the [CLI documentation](../../docs/getting-started/cli.md).
@@ -36,7 +36,9 @@ preserved unless you pass `--force`.
 
 The standalone CLI and this npm package are two distributions of the same
 `eudiplo` command. The standalone CLI removes the Node.js requirement, but
-Docker and Docker Compose are still required for the demo deployment.
+Docker and Docker Compose, or Podman and Podman Compose, are still required for
+the demo deployment. Docker is preferred by default; set
+`EUDIPLO_CONTAINER_RUNTIME=podman` to force Podman.
 
 ## Package and Binary Names
 
@@ -51,6 +53,24 @@ eudiplo status
 pnpm add -D @eudiplo/cli
 pnpm eudiplo status
 ```
+
+## Uninstall
+
+Use the removal path that matches how the CLI was installed:
+
+```bash
+# Standalone Linux/macOS installer
+rm "${EUDIPLO_INSTALL_DIR:-$HOME/.local/bin}/eudiplo"
+
+# npm global install
+npm uninstall -g @eudiplo/cli
+
+# project dependency
+pnpm remove @eudiplo/cli
+```
+
+The CLI stores instance metadata in `~/.eudiplo/config.json` by default. Remove
+`~/.eudiplo` only if you also want to delete local CLI instance registrations.
 
 ## Compose Driver Commands
 
@@ -95,7 +115,7 @@ stored under `config/<tenant-id>/`. The demo tenant is excluded by default and
 can be added with `--demo-tenant`.
 
 `init --target compose --demo` writes demo-specific assets (`.eudiplo.demo.env`
-and `config/demo`) without starting Docker Compose. Add `--no-client`
+and `config/demo`) without starting the Compose runtime. Add `--no-client`
 to generate a small Compose override that skips the web client container.
 
 `demo --reset --force` stops the managed demo stack, removes managed demo
@@ -181,9 +201,9 @@ running it:
 sha256sum -c SHA256SUMS.txt
 ```
 
-The standalone binary does not replace Docker or Docker Compose. You still need
-Docker to run the local deployment stack, but you do not need a local Node.js
-installation just to use the CLI itself.
+The standalone binary does not replace Docker, Podman, or Compose. You still
+need a container runtime to run the local deployment stack, but you do not need a
+local Node.js installation just to use the CLI itself.
 
 ## Developing and Extending the CLI
 
@@ -248,34 +268,34 @@ truth.
 
 ```ts
 // commands/example/index.ts
-import { Command } from "commander";
-import type { CommandContext } from "../../types.js";
-import type { SetExitCode } from "../shared.js";
-import { runExample } from "./action.js";
+import { Command } from 'commander';
+import type { CommandContext } from '../../types.js';
+import type { SetExitCode } from '../shared.js';
+import { runExample } from './action.js';
 
 export function createExampleCommand(
-    context: CommandContext,
-    setExitCode: SetExitCode,
+  context: CommandContext,
+  setExitCode: SetExitCode,
 ): Command {
-    return new Command("example")
-        .description("Describe what the command does")
-        .requiredOption("--input <path>", "input file")
-        .action(async (options) => {
-            setExitCode(await runExample(options.input, context));
-        });
+  return new Command('example')
+    .description('Describe what the command does')
+    .requiredOption('--input <path>', 'input file')
+    .action(async (options) => {
+      setExitCode(await runExample(options.input, context));
+    });
 }
 ```
 
 ```ts
 // commands/example/action.ts
-import type { CommandContext } from "../../types.js";
+import type { CommandContext } from '../../types.js';
 
 export async function runExample(
-    input: string,
-    context: CommandContext,
+  input: string,
+  context: CommandContext,
 ): Promise<number> {
-    context.stdout.write(`Processing ${input}\n`);
-    return 0;
+  context.stdout.write(`Processing ${input}\n`);
+  return 0;
 }
 ```
 

--- a/apps/cli/src/commands/demo/action.ts
+++ b/apps/cli/src/commands/demo/action.ts
@@ -70,7 +70,7 @@ export async function runDemo(
     });
     const nextConfig = upsertInstance(config, "local", instance);
     await saveConfig(configPath, nextConfig);
-    context.stdout.write("Starting EUDIPLO demo with Docker Compose...\n");
+    context.stdout.write("Starting EUDIPLO demo with the Compose runtime...\n");
     const exitCode =
         (await drivers.compose.up?.({
             instanceName: "local",

--- a/apps/cli/src/commands/deployment/index.ts
+++ b/apps/cli/src/commands/deployment/index.ts
@@ -18,7 +18,7 @@ export function createDeploymentCommands(
     return (["up", "down", "logs"] as const).map((name) =>
         new Command(name)
             .description(descriptions[name])
-            .argument("[args...]", "additional arguments passed to Docker Compose")
+            .argument("[args...]", "additional arguments passed to the Compose runtime")
             .option("--instance <name>", "select a configured Compose instance")
             .action(async (args, options) => {
                 const { config } = await loadCliState(context);

--- a/apps/cli/src/commands/init/action.ts
+++ b/apps/cli/src/commands/init/action.ts
@@ -87,7 +87,7 @@ export async function runInit(
         }
 
         if (initOptions.start) {
-            context.stdout.write("Starting EUDIPLO with Docker Compose...\n");
+            context.stdout.write("Starting EUDIPLO with the Compose runtime...\n");
             return (
                 (await drivers.compose.up?.({
                     instanceName: name,

--- a/apps/cli/src/services/deployment-drivers.ts
+++ b/apps/cli/src/services/deployment-drivers.ts
@@ -1,5 +1,5 @@
 import { access, mkdir, rm, stat, unlink, writeFile } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { delimiter, join, resolve } from "node:path";
 import { spawn } from "node:child_process";
 import {
     copyBundledDemoConfig,
@@ -23,14 +23,21 @@ import type {
     InstanceConfig,
 } from "../types.js";
 
+type ContainerRuntimeName = "docker" | "podman";
+
+interface ComposeRuntime {
+    command: string;
+    name: ContainerRuntimeName;
+}
+
 export const drivers: Record<DeploymentTarget, DeploymentDriver> = {
     compose: {
         target: "compose",
         async diagnostics(instance, context) {
             const messages: string[] = [];
             const projectDirectory = instance.projectDirectory ?? context.cwd;
-            if (!(await resolveDockerExecutable())) {
-                messages.push("Docker was not found in a supported install location.");
+            if (!(await resolveComposeRuntime(context.env))) {
+                messages.push("Docker or Podman was not found in a supported install location.");
             }
             for (const composeFile of getComposeFiles(instance)) {
                 try {
@@ -238,14 +245,14 @@ async function runCompose(
     }
     composeArgs.push(...args);
 
-    const dockerExecutable = await resolveDockerExecutable();
-    if (!dockerExecutable) {
-        context.stderr.write("Docker was not found in a supported install location.\n");
+    const composeRuntime = await resolveComposeRuntime(context.env);
+    if (!composeRuntime) {
+        context.stderr.write("Docker or Podman was not found in a supported install location.\n");
         return 1;
     }
 
     return new Promise((resolveProcess) => {
-        const child = spawn(dockerExecutable, composeArgs, {
+        const child = spawn(composeRuntime.command, composeArgs, {
             cwd: projectDirectory,
             env: context.env,
             stdio: "inherit",
@@ -259,19 +266,87 @@ async function runCompose(
     });
 }
 
-async function resolveDockerExecutable(): Promise<string | undefined> {
-    const executablePaths =
-        process.platform === "win32"
-            ? [String.raw`C:\Program Files\Docker\Docker\resources\bin\docker.exe`]
-            : ["/usr/local/bin/docker", "/opt/homebrew/bin/docker", "/usr/bin/docker"];
+export async function resolveComposeRuntime(
+    env: NodeJS.ProcessEnv,
+): Promise<ComposeRuntime | undefined> {
+    const preferredRuntime = parsePreferredRuntime(env.EUDIPLO_CONTAINER_RUNTIME);
+    const candidates = preferredRuntime
+        ? [preferredRuntime]
+        : (["docker", "podman"] as const);
 
-    for (const executablePath of executablePaths) {
+    for (const runtime of candidates) {
+        const command = await resolveRuntimeExecutable(runtime, env);
+        if (command) {
+            return { command, name: runtime };
+        }
+    }
+
+    return undefined;
+}
+
+function parsePreferredRuntime(value: string | undefined): ContainerRuntimeName | undefined {
+    if (!value) {
+        return undefined;
+    }
+    if (value === "docker" || value === "podman") {
+        return value;
+    }
+    throw new Error("EUDIPLO_CONTAINER_RUNTIME must be docker or podman.");
+}
+
+async function resolveRuntimeExecutable(
+    runtime: ContainerRuntimeName,
+    env: NodeJS.ProcessEnv,
+): Promise<string | undefined> {
+    for (const executablePath of runtimeExecutablePaths(runtime, env)) {
         if (await exists(executablePath)) {
             return executablePath;
         }
     }
 
     return undefined;
+}
+
+function runtimeExecutablePaths(
+    runtime: ContainerRuntimeName,
+    env: NodeJS.ProcessEnv,
+): string[] {
+    const pathCandidates = (env.PATH ?? "")
+        .split(delimiter)
+        .filter(Boolean)
+        .flatMap((pathEntry) => runtimePathCandidates(pathEntry, runtime, env));
+
+    if (process.platform === "win32") {
+        if (runtime === "docker") {
+            return [
+                String.raw`C:\Program Files\Docker\Docker\resources\bin\docker.exe`,
+                ...pathCandidates,
+            ];
+        }
+        return [String.raw`C:\Program Files\RedHat\Podman\podman.exe`, ...pathCandidates];
+    }
+
+    return [
+        `/usr/local/bin/${runtime}`,
+        `/opt/homebrew/bin/${runtime}`,
+        `/usr/bin/${runtime}`,
+        ...pathCandidates,
+    ];
+}
+
+function runtimePathCandidates(
+    pathEntry: string,
+    runtime: ContainerRuntimeName,
+    env: NodeJS.ProcessEnv,
+): string[] {
+    if (process.platform !== "win32") {
+        return [join(pathEntry, runtime)];
+    }
+
+    const extensions = (env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM")
+        .split(";")
+        .filter(Boolean);
+    return [join(pathEntry, runtime), ...extensions.map((ext) => join(pathEntry, `${runtime}${ext}`))];
 }
 
 async function exists(path: string): Promise<boolean> {

--- a/apps/cli/test/runtime.test.ts
+++ b/apps/cli/test/runtime.test.ts
@@ -1,8 +1,8 @@
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { chmod, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { basename, join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
-import { drivers } from "../src/services/deployment-drivers.js";
+import { drivers, resolveComposeRuntime } from "../src/services/deployment-drivers.js";
 import { runCli } from "../src/runtime.js";
 import type { CommandContext } from "../src/types.js";
 
@@ -456,7 +456,7 @@ describe("EUDIPLO CLI", () => {
             const code = await runCli(["init", "--preset", "full", "--start"], context);
 
             expect(code).toBe(0);
-            expect(output.stdout).toContain("Starting EUDIPLO with Docker Compose...");
+            expect(output.stdout).toContain("Starting EUDIPLO with the Compose runtime...");
             expect(profiles).toEqual(["postgres", "s3", "vault"]);
         } finally {
             drivers.compose.up = originalUp;
@@ -577,6 +577,29 @@ describe("EUDIPLO CLI", () => {
         }
     });
 
+    it("selects Podman when requested with EUDIPLO_CONTAINER_RUNTIME", async () => {
+        const { cwd } = await createContext();
+        const binDirectory = join(cwd, "bin");
+        const podmanPath = join(binDirectory, "podman");
+        await mkdir(binDirectory);
+        await writeFile(podmanPath, "#!/bin/sh\nexit 0\n", "utf8");
+        await chmod(podmanPath, 0o700);
+
+        const runtime = await resolveComposeRuntime({
+            EUDIPLO_CONTAINER_RUNTIME: "podman",
+            PATH: binDirectory,
+        });
+
+        expect(runtime?.name).toBe("podman");
+        expect(basename(runtime?.command ?? "")).toBe("podman");
+    });
+
+    it("rejects unsupported container runtime preferences", async () => {
+        await expect(
+            resolveComposeRuntime({ EUDIPLO_CONTAINER_RUNTIME: "nerdctl" }),
+        ).rejects.toThrow("EUDIPLO_CONTAINER_RUNTIME must be docker or podman.");
+    });
+
     it("demo generates local assets and starts compose", async () => {
         const { context, output, cwd } = await createContext();
         const originalUp = drivers.compose.up;
@@ -586,7 +609,7 @@ describe("EUDIPLO CLI", () => {
             const code = await runCli(["demo"], context);
 
             expect(code).toBe(0);
-            expect(output.stdout).toContain("Starting EUDIPLO demo with Docker Compose...");
+            expect(output.stdout).toContain("Starting EUDIPLO demo with the Compose runtime...");
             expect(output.stdout).toContain("Demo mode - not for production.");
             await expect(readFile(join(cwd, ".eudiplo.demo.env"), "utf8")).resolves.toContain(
                 "EUDIPLO_IMAGE=ghcr.io/openwallet-foundation/eudiplo:latest",

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -9,6 +9,7 @@ The command name is `eudiplo` in both cases.
 
 For focused guidance, see:
 
+- [Server setup cookbook](cli/server-setup-cookbook.md)
 - [Configuration validation](cli/configuration-validation.md)
 - [Local development](cli/development.md)
 
@@ -60,6 +61,38 @@ eudiplo --version
 - `npx @eudiplo/cli ...` runs the package without a global install.
 - `eudiplo ...` runs the installed command (standalone or npm-installed).
 
+## Uninstall
+
+Use the removal path that matches how the CLI was installed. A separate
+`eudiplo uninstall` command is intentionally not provided because the executable
+may be managed by npm, a release archive, or a local installation directory.
+
+For the standalone Linux/macOS installer, remove the installed binary:
+
+```bash
+rm "${EUDIPLO_INSTALL_DIR:-$HOME/.local/bin}/eudiplo"
+```
+
+If you installed the npm package globally, remove it with npm:
+
+```bash
+npm uninstall -g @eudiplo/cli
+```
+
+If you added it to a project, remove the project dependency with your package
+manager, for example:
+
+```bash
+pnpm remove @eudiplo/cli
+```
+
+The CLI stores instance metadata in `~/.eudiplo/config.json` by default. Remove
+that directory only if you also want to delete local CLI instance registrations:
+
+```bash
+rm -rf ~/.eudiplo
+```
+
 ## Run a Local Demo Deployment
 
 ```bash
@@ -81,7 +114,11 @@ local file storage, database-backed key management, and the web client:
 - `config/demo` (editable generated demo tenant configuration)
 
 The standalone CLI removes the Node.js requirement only. Docker and Docker
-Compose are still required for `demo`.
+Compose, or Podman and Podman Compose, are still required for `demo`.
+
+Docker is preferred by default. If Docker is not found, the CLI tries Podman.
+Set `EUDIPLO_CONTAINER_RUNTIME=docker` or `EUDIPLO_CONTAINER_RUNTIME=podman` to
+force a specific Compose runtime.
 
 Demo mode warning: generated demo credentials are for local onboarding only and
 must not be used in production.
@@ -165,11 +202,11 @@ explicitly use the DB provider, even when Vault is the default for new keys.
 
 All wizard choices are also available as flags for repeatable setup:
 
-| Preset | Database | Storage | Key management |
-| --- | --- | --- | --- |
-| `minimal` | SQLite | Local filesystem | Database-backed |
+| Preset     | Database   | Storage            | Key management  |
+| ---------- | ---------- | ------------------ | --------------- |
+| `minimal`  | SQLite     | Local filesystem   | Database-backed |
 | `standard` | PostgreSQL | S3 via local MinIO | Database-backed |
-| `full` | PostgreSQL | S3 via local MinIO | Vault |
+| `full`     | PostgreSQL | S3 via local MinIO | Vault           |
 
 Explicit `--database`, `--storage`, and `--kms` flags override the corresponding
 preset choices. Use `--yes` or `--no-interactive` to suppress the wizard. Use

--- a/docs/getting-started/cli/server-setup-cookbook.md
+++ b/docs/getting-started/cli/server-setup-cookbook.md
@@ -1,0 +1,457 @@
+# Server Setup Cookbook
+
+This guide is a copy-and-follow path for setting up EUDIPLO on a fresh Linux
+server, or on your local machine, with the EUDIPLO CLI, a Compose runtime, and
+file-based tenant configuration.
+
+Use this cookbook when you want one EUDIPLO instance with one or more tenants
+managed from local JSON config folders. For a short local demo, use
+[`eudiplo demo`](../quick-start.md) instead.
+
+By the end, you should have a running backend, a healthy CLI check, one tenant
+configuration imported from files, and a clear next path into issuance and
+presentation setup.
+
+## What You Will Build
+
+The steps below create a Compose-managed EUDIPLO project with:
+
+- EUDIPLO backend
+- optional web client
+- SQLite and local storage for the `minimal` preset, or PostgreSQL and MinIO
+  for the `standard` preset
+- one mounted `config/` folder for tenants
+- startup config import enabled
+
+Tenant setup in this guide is file-based. The CLI creates tenant config folders
+locally; the running backend imports them when it starts. To create tenants in a
+running instance without restarting, use the Web Client or API.
+
+## Happy Path
+
+If you already have Docker or Podman and want the shortest successful path, run
+these commands and then come back to the detailed sections when you need to
+change something:
+
+```bash
+curl -fsSL https://eudiplo.dev/install.sh | bash
+mkdir -p ~/eudiplo
+cd ~/eudiplo
+
+eudiplo init . --preset minimal --public-url http://localhost:3000 --start
+eudiplo doctor
+
+eudiplo config tenant create acme --name "Acme GmbH"
+eudiplo config tenant validate acme
+eudiplo down
+eudiplo up
+eudiplo doctor
+```
+
+Success looks like:
+
+- `eudiplo doctor` reports the API and health endpoint as reachable.
+- `eudiplo config tenant list` shows `acme`.
+- `eudiplo logs eudiplo` does not show config-import validation errors.
+
+## 1. Prepare the Server
+
+Install Docker with Docker Compose v2, or Podman with Podman Compose, using the
+package instructions for your Linux distribution. Then verify the runtime you
+want to use:
+
+```bash
+docker --version
+docker compose version
+```
+
+or:
+
+```bash
+podman --version
+podman compose version
+```
+
+!!! note "Using Podman instead of Docker"
+
+    The CLI-managed Compose commands (`eudiplo up`, `eudiplo down`, and
+    `eudiplo logs`) can use Docker or Podman. Docker is preferred by default;
+    if Docker is not found, the CLI tries Podman. To force one runtime, set
+    `EUDIPLO_CONTAINER_RUNTIME`:
+
+    ```bash
+    export EUDIPLO_CONTAINER_RUNTIME=podman
+    # or
+    export EUDIPLO_CONTAINER_RUNTIME=docker
+    ```
+
+    Validate the generated Compose file with your selected runtime before using
+    it for a shared environment.
+
+Install the standalone EUDIPLO CLI:
+
+```bash
+curl -fsSL https://eudiplo.dev/install.sh | bash
+eudiplo --version
+```
+
+The standalone CLI removes the Node.js requirement. Docker or a compatible
+Compose runtime is still required to run the deployment.
+
+## 2. Choose a Public URL
+
+Decide which URL wallets and administrators will use to reach the backend.
+
+You can run this cookbook on your local machine as well as on a remote server.
+For local testing without wallet interaction, use:
+
+```text
+http://localhost:3000
+```
+
+When EUDIPLO needs to interact with a wallet on another device, the wallet must
+be able to reach the backend URL in offers, requests, and metadata. In that case,
+expose your local backend with a tunnel or reverse proxy such as ngrok and use
+the public tunnel URL as `PUBLIC_URL`:
+
+```text
+https://your-tunnel.example.com
+```
+
+For a real server behind DNS and TLS, use your external URL:
+
+```text
+https://eudiplo.example.com
+```
+
+The value is written to `PUBLIC_URL` and is used for OAuth, OpenID, and wallet
+redirects. Configure your reverse proxy and TLS before using an HTTPS public URL
+in production.
+
+## 3. Initialize the EUDIPLO Project
+
+Run the setup wizard. It asks for the project directory, preset, public URL,
+authentication client, web client, and whether to start immediately.
+
+Choose the preset based on how much infrastructure you want to run:
+
+| Preset     | Services                                                               | Best for                                                                   |
+| ---------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `minimal`  | EUDIPLO backend, optional web client, SQLite, local filesystem storage | Local evaluation, small test servers, and the fewest moving parts          |
+| `standard` | EUDIPLO backend, optional web client, PostgreSQL, MinIO                | Staging, longer-running test environments, and setups closer to production |
+
+For the smallest local or test setup, use `minimal`:
+
+```bash
+mkdir -p ~/eudiplo
+cd ~/eudiplo
+eudiplo init . --preset minimal --public-url http://localhost:3000
+```
+
+For a server with PostgreSQL and MinIO, use `standard`:
+
+```bash
+mkdir -p ~/eudiplo
+cd ~/eudiplo
+eudiplo init . --preset standard --public-url https://eudiplo.example.com
+```
+
+Recommended wizard choices:
+
+| Prompt                     | Recommended value                                                 |
+| -------------------------- | ----------------------------------------------------------------- |
+| Preset                     | `minimal` for fewer services, `standard` for PostgreSQL and MinIO |
+| Database                   | SQLite for `minimal`, PostgreSQL for `standard`                   |
+| Storage                    | Local filesystem for `minimal`, S3 via MinIO for `standard`       |
+| Key management             | Database-backed                                                   |
+| Web client                 | enabled, unless you only want API access                          |
+| Start after initialization | yes                                                               |
+
+The CLI creates files similar to:
+
+```text
+~/eudiplo/
+  .eudiplo.env
+  eudiplo.compose.yaml
+  config/
+    kms.json
+```
+
+The generated environment file includes:
+
+```env
+EUDIPLO_CONFIG_MOUNT=./config:/app/config
+CONFIG_FOLDER=/app/config
+CONFIG_IMPORT=true
+CONFIG_IMPORT_FORCE=false
+```
+
+That means every tenant directory under `config/` is scanned during backend
+startup and imported if it is valid.
+
+!!! tip "Automated setup"
+
+    For non-interactive automation, pass all required values as flags:
+
+    ```bash
+    eudiplo init ~/eudiplo \
+      --preset minimal \
+      --public-url http://localhost:3000 \
+      --auth-client-id root \
+      --auth-client-secret '<root-client-secret>' \
+      --no-interactive \
+      --start
+    ```
+
+    Avoid putting real shared secrets in shell history. On shared servers, prefer
+    the interactive wizard or your secret-management tooling.
+
+## 4. Start or Check the Instance
+
+If you did not start the stack during initialization, start it now:
+
+```bash
+eudiplo up
+```
+
+On a Podman-only host, force Podman before running CLI-managed lifecycle
+commands:
+
+```bash
+export EUDIPLO_CONTAINER_RUNTIME=podman
+eudiplo up
+```
+
+Check container status and logs:
+
+```bash
+docker compose -f ~/eudiplo/eudiplo.compose.yaml --env-file ~/eudiplo/.eudiplo.env ps
+eudiplo logs
+```
+
+Run the CLI health checks:
+
+```bash
+eudiplo doctor --instance local
+eudiplo status --instance local
+```
+
+You can also check the backend directly:
+
+```bash
+curl http://localhost:3000/health
+```
+
+## 5. Add the First Tenant from the CLI
+
+Create a tenant config folder:
+
+```bash
+eudiplo config tenant create acme --name "Acme GmbH"
+```
+
+This creates:
+
+```text
+~/eudiplo/config/acme/
+  info.json
+  clients/
+  key-chains/
+  certs/
+  attribute-providers/
+  webhook-endpoints/
+  issuance/
+  presentation/
+  trust-lists/
+  images/
+```
+
+Validate the tenant before importing it:
+
+```bash
+eudiplo config tenant validate acme
+```
+
+Restart the stack so the backend runs config import on startup:
+
+```bash
+eudiplo down
+eudiplo up
+```
+
+Confirm the instance is still healthy:
+
+```bash
+eudiplo doctor --instance local
+```
+
+At this point, the basic installation is done. You have a running EUDIPLO
+instance and a tenant config folder that can be extended with issuance and
+presentation resources.
+
+## 6. Add a Tenant from the Demo Template
+
+For a faster test tenant with bundled example resources, use the demo template:
+
+```bash
+eudiplo config tenant create sample --template demo
+eudiplo config tenant validate sample
+eudiplo down
+eudiplo up
+```
+
+The demo template is useful for onboarding and testing. Do not use bundled demo
+private keys or demo credentials in production.
+
+## 7. List Local Tenant Configurations
+
+List tenant folders managed by this Compose instance:
+
+```bash
+eudiplo config tenant list
+```
+
+Validate every tenant folder before the next restart:
+
+```bash
+eudiplo config validate tenants ~/eudiplo/config
+```
+
+## 8. Manage the Instance Later
+
+Common lifecycle commands:
+
+```bash
+eudiplo status
+eudiplo doctor
+eudiplo logs
+eudiplo down
+eudiplo up
+```
+
+The CLI stores the `local` instance metadata in your user-level CLI config, so
+these commands can be run from any directory after initialization.
+
+## 9. Developer Workflow
+
+After the first setup, most local changes follow the same loop:
+
+```bash
+cd ~/eudiplo
+
+# Edit tenant config files under config/<tenant-id>/
+eudiplo config tenant validate acme
+
+# Restart so startup config import runs again
+eudiplo down
+eudiplo up
+
+# Check whether the instance is reachable and healthy
+eudiplo doctor
+```
+
+Useful files and directories:
+
+| Path                               | Purpose                                                         |
+| ---------------------------------- | --------------------------------------------------------------- |
+| `.eudiplo.env`                     | Runtime environment for the generated Compose stack             |
+| `eudiplo.compose.yaml`             | Generated Compose file used by `eudiplo up`, `down`, and `logs` |
+| `config/kms.json`                  | Global key-management provider configuration                    |
+| `config/<tenant-id>/info.json`     | Tenant metadata imported on startup                             |
+| `config/<tenant-id>/clients/`      | Tenant clients imported on startup                              |
+| `config/<tenant-id>/issuance/`     | Issuance and credential configuration files                     |
+| `config/<tenant-id>/presentation/` | Presentation request configuration files                        |
+
+Useful commands while editing:
+
+```bash
+# List local tenant config folders
+eudiplo config tenant list
+
+# Validate one tenant
+eudiplo config tenant validate acme
+
+# Validate all tenants in the config root
+eudiplo config validate tenants ~/eudiplo/config
+
+# Follow backend/client logs through the selected Compose runtime
+eudiplo logs
+
+# Pass extra Compose arguments through the CLI
+eudiplo logs eudiplo
+eudiplo down --volumes --remove-orphans
+```
+
+If you change `.eudiplo.env`, restart the stack. If you change tenant config
+JSON, validate it before restarting so import errors are caught before startup.
+
+## 10. Register an Externally Managed Instance
+
+If the server is managed outside the CLI, for example with Kubernetes, Helm, or
+your own Compose files, register it as an external instance instead:
+
+```bash
+eudiplo instance add production --url https://eudiplo.example.com
+eudiplo doctor --instance production
+```
+
+For external instances, `up`, `down`, `logs`, and local tenant folder discovery
+are not available. You can still validate config folders explicitly:
+
+```bash
+eudiplo config validate tenants ./config
+```
+
+## Go Deeper
+
+Once the cookbook works end to end, continue by defining what the tenant should
+issue and verify.
+
+Start with issuance:
+
+- [Credential configuration](../issuance/credential-configuration.md) defines
+  the credential format, claims, display metadata, and proof settings.
+- [Issuance configuration](../issuance/issuance-configuration.md) defines issuer
+  metadata and which credentials can be offered.
+- [Credential offers](../issuance/credential-offers.md) explains how to create
+  offers for wallets.
+
+Then add presentation:
+
+- [Presentation configuration](../presentation/presentation-configuration.md)
+  defines what credentials to request from wallets.
+- [Presentation requests](../presentation/presentation-requests.md) explains how
+  to start verification flows.
+- [Transaction data](../presentation/transaction-data.md) covers signed
+  transaction payloads for higher-assurance flows.
+
+Keep the same local workflow while you go deeper: edit files under
+`config/<tenant-id>/`, validate the tenant, restart the stack, then check
+`eudiplo doctor` and `eudiplo logs eudiplo`.
+
+## Common Problems
+
+| Symptom                                | What to check                                                                                                                                            |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Docker or Podman was not found`       | Install Docker/Podman, verify it is on `PATH`, or set `EUDIPLO_CONTAINER_RUNTIME` to the runtime you want.                                               |
+| Wallet cannot scan or complete a flow  | Ensure `PUBLIC_URL` is reachable from the wallet device. For local development, use a tunnel or reverse proxy and reinitialize or update `.eudiplo.env`. |
+| Tenant does not appear after restart   | Run `eudiplo config validate tenants ~/eudiplo/config`, then check `eudiplo logs` for config-import messages.                                            |
+| Login fails                            | Verify `AUTH_CLIENT_ID`, `AUTH_CLIENT_SECRET`, and `MASTER_SECRET` in `.eudiplo.env`, then restart the stack.                                            |
+| `eudiplo logs` follows too much output | Pass a service name, for example `eudiplo logs eudiplo`.                                                                                                 |
+
+## Production Notes
+
+Before exposing the instance to real users:
+
+- Replace default or demo credentials.
+- Use a strong `MASTER_SECRET` and keep it stable for the lifetime of encrypted
+  data.
+- Put the backend behind TLS and set `PUBLIC_URL` to the HTTPS URL.
+- Back up PostgreSQL, MinIO data, and the `config/` directory.
+- Use Vault or another production key-management strategy when required by your
+  security model.
+- Validate tenant config in CI before deploying or restarting.
+
+More details are available in the [Docker Compose deployment guide](../../deployment/docker-compose.md),
+[configuration import guide](../../architecture/configuration-import.md), and
+[CLI reference](../cli.md).

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -52,8 +52,9 @@ eudiplo demo
 ```
 
 Both options run the same **EUDIPLO CLI**. The standalone CLI removes the
-Node.js requirement, but Docker and Docker Compose are still required for
-`eudiplo demo`.
+Node.js requirement, but Docker and Docker Compose, or Podman and Podman
+Compose, are still required for `eudiplo demo`. Docker is preferred by default;
+set `EUDIPLO_CONTAINER_RUNTIME=podman` to force Podman.
 
 The CLI asks for a project directory and suggests `./`. Accepting the default
 generates editable demo files in your current directory:

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,12 +71,22 @@ Both options run the same **EUDIPLO CLI**.
 
 - **Standalone CLI**: native executable, no Node.js required.
 - **npm package**: `@eudiplo/cli`, requires Node.js 22+.
-- The demo requires Docker and Docker Compose.
+- The demo requires Docker and Docker Compose, or Podman and Podman Compose.
 - `eudiplo demo` creates a local demo deployment for evaluation, not production.
 
-Continue with:
+## What Should I Do Next?
 
-- [Quick Start](./getting-started/quick-start.md)
+If you are new to EUDIPLO, follow this path:
+
+| Step | Guide                                                                                      | Goal                                                                   |
+| ---- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
+| 1    | [Quick Start](./getting-started/quick-start.md)                                            | Run the demo and confirm EUDIPLO works on your machine.                |
+| 2    | [Server setup cookbook](./getting-started/cli/server-setup-cookbook.md)                    | Set up a reusable local or server instance with tenant config folders. |
+| 3    | [Credential configuration](./getting-started/issuance/credential-configuration.md)         | Define what your tenant can issue.                                     |
+| 4    | [Presentation configuration](./getting-started/presentation/presentation-configuration.md) | Define what your tenant can verify.                                    |
+
+Useful references once the first setup works:
+
 - [CLI documentation](./getting-started/cli.md)
 - [Production deployment](./deployment/index.md)
 - [GitHub Releases](https://github.com/openwallet-foundation/eudiplo/releases)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
       - Web Client: getting-started/web-client.md
       - CLI:
         - Overview: getting-started/cli.md
+        - Server Setup Cookbook: getting-started/cli/server-setup-cookbook.md
         - Configuration Validation: getting-started/cli/configuration-validation.md
         - Local Development: getting-started/cli/development.md
       - Flows:


### PR DESCRIPTION
## 📝 Description

Adds a cookbook-style CLI setup guide that gives new users a straight path from first setup to tenant configuration and then into issuance/presentation configuration. Also extends the CLI Compose driver so lifecycle commands can use Docker or Podman via runtime detection or `EUDIPLO_CONTAINER_RUNTIME`.

Fixes #(issue number)

## 🔄 Type of Change

Please delete options that are not relevant:

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test improvements
- [ ] 🏗️ Build/CI changes

## 💥 Breaking Changes (if applicable)

None.

## 🧪 Testing

Describe the tests that you ran to verify your changes:

- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] E2E tests pass
- [x] Manual testing performed

**Test Configuration**:

- Node.js version: repository default/toolchain
- OS: macOS
- Test environment: local workspace

Commands run:

```bash
pnpm --filter @eudiplo/cli test
pnpm --filter @eudiplo/cli lint
pnpm --filter @eudiplo/cli build
pnpm exec markdownlint docs/getting-started/cli/server-setup-cookbook.md docs/getting-started/cli.md docs/getting-started/quick-start.md docs/index.md apps/cli/README.md
source venv/bin/activate && mkdocs build --strict
```

## 📸 Screenshots (if applicable)

Not applicable.

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 📋 Additional Notes

SonarQube `analyze_file_list` was attempted repeatedly during the work, but the tool returned `Failed to request analysis of the list of files. Check logs for details.` Automatic analysis was re-enabled afterward.