### PR TITLE
Add CLI instance management, config inspection, and completion

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -154,9 +154,29 @@ EUDIPLO_CLI_HOME=/tmp/eudiplo-cli eudiplo config validate
 EUDIPLO_CLI_CONFIG=/tmp/eudiplo-cli/config.json eudiplo config validate
 ```
 
+Print the resolved file path or inspect the validated configuration with:
+
+```bash
+eudiplo config path
+eudiplo config show
+eudiplo config show --json
+```
+
 Do not store secrets in the CLI config. Commands that need authenticated API
 access read credentials from environment variables such as `EUDIPLO_CLIENT_ID`
 and `EUDIPLO_CLIENT_SECRET`.
+
+## Shell Completion
+
+The CLI generates completion scripts for Bash, Zsh, Fish, and PowerShell. For
+the current shell session, use one of:
+
+```bash
+source <(eudiplo completion bash)
+source <(eudiplo completion zsh)
+eudiplo completion fish | source
+eudiplo completion powershell | Out-String | Invoke-Expression
+```
 
 ## Single Executable Application
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -17,6 +17,9 @@ installer instead: `curl -fsSL https://eudiplo.dev/install.sh | bash`
 ```bash
 npx @eudiplo/cli demo ./eudiplo-demo
 npx @eudiplo/cli instance add production --url https://eudiplo.example.com
+npx @eudiplo/cli instance ls
+npx @eudiplo/cli instance show production
+npx @eudiplo/cli instance use production
 npx @eudiplo/cli doctor --instance production
 ```
 

--- a/apps/cli/src/commands/completion/action.ts
+++ b/apps/cli/src/commands/completion/action.ts
@@ -1,0 +1,160 @@
+import type { Command, Option } from "commander";
+import type { CommandContext } from "../../types.js";
+
+export type CompletionShell = "bash" | "zsh" | "fish" | "powershell";
+
+export function runCompletion(
+    shell: CompletionShell,
+    context: CommandContext,
+): number {
+    context.stdout.write(`${completionScript(shell)}\n`);
+    return 0;
+}
+
+export function runCompletionCandidates(
+    root: Command,
+    words: string[],
+    context: CommandContext,
+): number {
+    for (const candidate of completionCandidates(root, words)) {
+        context.stdout.write(`${candidate}\n`);
+    }
+    return 0;
+}
+
+function completionScript(shell: CompletionShell): string {
+    switch (shell) {
+        case "bash":
+            return bashCompletion();
+        case "zsh":
+            return zshCompletion();
+        case "fish":
+            return fishCompletion();
+        case "powershell":
+            return powershellCompletion();
+    }
+}
+
+function completionCandidates(root: Command, words: string[]): string[] {
+    let current = root;
+    let skipOptionValue = false;
+    for (const word of words) {
+        if (skipOptionValue) {
+            skipOptionValue = false;
+            continue;
+        }
+        const option = findOption(current, word);
+        if (option) {
+            skipOptionValue = option.required || option.optional;
+            continue;
+        }
+        if (word.startsWith("-")) {
+            continue;
+        }
+        const child = current.commands.find(
+            (command) => command.name() === word || command.aliases().includes(word),
+        );
+        if (child) {
+            current = child;
+        }
+    }
+
+    const lastOption = findOption(current, words.at(-1));
+    if (lastOption) {
+        const choices = optionChoices(lastOption);
+        if (choices.length > 0) {
+            return choices;
+        }
+    }
+
+    const candidates = ["-h", "--help"];
+    for (const command of current.commands) {
+        if (command.name() !== "_complete") {
+            candidates.push(command.name(), ...command.aliases());
+        }
+    }
+    for (const option of current.options) {
+        if (option.short) {
+            candidates.push(option.short);
+        }
+        if (option.long) {
+            candidates.push(option.long);
+        }
+    }
+
+    if (current.commands.length === 0 && words.at(-1) === current.name()) {
+        candidates.push(...(current.registeredArguments[0]?.argChoices ?? []));
+    }
+    return [...new Set(candidates)];
+}
+
+function findOption(command: Command, word: string | undefined): Option | undefined {
+    if (!word) {
+        return undefined;
+    }
+    const flag = word.includes("=") ? word.slice(0, word.indexOf("=")) : word;
+    return command.options.find(
+        (option) => option.short === flag || option.long === flag,
+    );
+}
+
+function optionChoices(option: Option): string[] {
+    if (option.argChoices) {
+        return option.argChoices;
+    }
+    const placeholder = option.flags.match(/[<[]([^>\]]+)[>\]]/u)?.[1];
+    return placeholder?.includes("|") ? placeholder.split("|") : [];
+}
+
+function bashCompletion(): string {
+    return [
+        "_eudiplo_completion() {",
+        "    local current candidates",
+        "    local -a args",
+        '    current="${COMP_WORDS[COMP_CWORD]}"',
+        '    args=("${COMP_WORDS[@]:1:$((COMP_CWORD - 1))}")',
+        '    candidates="$(eudiplo _complete "${args[@]}" 2>/dev/null)"',
+        '    COMPREPLY=($(compgen -W "$candidates" -- "$current"))',
+        "}",
+        "complete -F _eudiplo_completion eudiplo",
+    ].join("\n");
+}
+
+function zshCompletion(): string {
+    return [
+        "#compdef eudiplo",
+        "_eudiplo() {",
+        "    local -a args candidates",
+        '    args=("${words[@]:2:$((CURRENT - 2))}")',
+        '    candidates=("${(@f)$(eudiplo _complete "${args[@]}" 2>/dev/null)}")',
+        "    compadd -- $candidates",
+        "}",
+        "compdef _eudiplo eudiplo",
+    ].join("\n");
+}
+
+function fishCompletion(): string {
+    return [
+        "function __eudiplo_candidates",
+        "    set -l tokens (commandline -opc)",
+        "    set -e tokens[1]",
+        "    eudiplo _complete $tokens 2>/dev/null",
+        "end",
+        "complete -c eudiplo -f -a '(__eudiplo_candidates)'",
+    ].join("\n");
+}
+
+function powershellCompletion(): string {
+    return [
+        "Register-ArgumentCompleter -Native -CommandName eudiplo -ScriptBlock {",
+        "    param($wordToComplete, $commandAst, $cursorPosition)",
+        "    $arguments = @($commandAst.CommandElements | Select-Object -Skip 1 | ForEach-Object { $_.ToString() })",
+        "    if ($wordToComplete -and $arguments.Count -gt 0) {",
+        "        $arguments = @($arguments | Select-Object -First ($arguments.Count - 1))",
+        "    }",
+        "    eudiplo _complete @arguments 2>$null | Where-Object { $_ -like \"$wordToComplete*\" } | ForEach-Object {",
+        "        [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)",
+        "    }",
+        "}",
+    ].join("\n");
+}

--- a/apps/cli/src/commands/completion/index.ts
+++ b/apps/cli/src/commands/completion/index.ts
@@ -1,0 +1,41 @@
+import { Argument, Command, type OptionValues } from "commander";
+import type { CommandContext } from "../../types.js";
+import type { SetExitCode } from "../shared.js";
+import {
+    runCompletion,
+    runCompletionCandidates,
+    type CompletionShell,
+} from "./action.js";
+
+const supportedShells: CompletionShell[] = ["bash", "zsh", "fish", "powershell"];
+
+export function createCompletionCommand(
+    context: CommandContext,
+    setExitCode: SetExitCode,
+): Command {
+    return new Command("completion")
+        .description("Generate shell completion scripts")
+        .addArgument(
+            new Argument("<shell>", "shell to generate completion for").choices(
+                supportedShells,
+            ),
+        )
+        .action((shell: CompletionShell) => {
+            setExitCode(runCompletion(shell, context));
+        });
+}
+
+export function createCompletionCandidatesCommand(
+    context: CommandContext,
+    setExitCode: SetExitCode,
+): Command {
+    return new Command("_complete")
+        .argument("[words...]")
+        .allowUnknownOption(true)
+        .action((words: string[], _options: OptionValues, command: Command) => {
+            if (!command.parent) {
+                throw new Error("Completion command is not attached to the CLI root.");
+            }
+            setExitCode(runCompletionCandidates(command.parent, words, context));
+        });
+}

--- a/apps/cli/src/commands/config/action.ts
+++ b/apps/cli/src/commands/config/action.ts
@@ -1,0 +1,47 @@
+import { resolveConfigPath } from "../../services/cli-config.js";
+import type { CliConfig, CommandContext, InstanceConfig } from "../../types.js";
+
+export function runConfigPath(context: CommandContext): number {
+    context.stdout.write(`${resolveConfigPath(context.env)}\n`);
+    return 0;
+}
+
+export function runConfigShow(
+    configPath: string,
+    config: CliConfig,
+    json: boolean,
+    context: CommandContext,
+): number {
+    if (json) {
+        context.stdout.write(`${JSON.stringify(config, null, 2)}\n`);
+        return 0;
+    }
+
+    context.stdout.write(`Config: ${configPath}\n`);
+    context.stdout.write(`Default instance: ${config.defaultInstance ?? "none"}\n`);
+    const instances = Object.entries(config.instances).sort(([left], [right]) =>
+        left.localeCompare(right),
+    );
+    if (instances.length === 0) {
+        context.stdout.write("Instances: none\n");
+        return 0;
+    }
+
+    context.stdout.write("Instances:\n");
+    for (const [name, instance] of instances) {
+        const defaultLabel = name === config.defaultInstance ? " (default)" : "";
+        context.stdout.write(`- ${name}${defaultLabel}\n`);
+        writeInstance(instance, context);
+    }
+    return 0;
+}
+
+function writeInstance(instance: InstanceConfig, context: CommandContext): void {
+    for (const [key, value] of Object.entries(instance)) {
+        if (value !== undefined) {
+            context.stdout.write(
+                `  ${key}: ${Array.isArray(value) ? value.join(", ") : value}\n`,
+            );
+        }
+    }
+}

--- a/apps/cli/src/commands/config/index.ts
+++ b/apps/cli/src/commands/config/index.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
+import { runConfigPath, runConfigShow } from "./action.js";
 import type { CommandContext } from "../../types.js";
-import type { SetExitCode } from "../shared.js";
+import { loadCliState, type SetExitCode } from "../shared.js";
 import { createTenantCommand } from "./tenant/index.js";
 import { createValidateCommand } from "./validate/index.js";
 
@@ -11,6 +12,20 @@ export function createConfigCommand(
     const config = new Command("config")
         .description("Validate and manage local configuration")
         .helpCommand(true);
+    config
+        .command("path")
+        .description("Print the active CLI config file path")
+        .action(() => {
+            setExitCode(runConfigPath(context));
+        });
+    config
+        .command("show")
+        .description("Show the validated CLI configuration")
+        .option("--json", "print config as JSON")
+        .action(async (options) => {
+            const { configPath, config } = await loadCliState(context);
+            setExitCode(runConfigShow(configPath, config, options.json === true, context));
+        });
     config.addCommand(createValidateCommand(context, setExitCode));
     config.addCommand(createTenantCommand(context, setExitCode));
     config.action(function showConfigHelp() {

--- a/apps/cli/src/commands/instance/action.ts
+++ b/apps/cli/src/commands/instance/action.ts
@@ -1,5 +1,10 @@
 import { readStringFlag } from "../../options.js";
-import { saveConfig, upsertInstance } from "../../services/cli-config.js";
+import {
+    removeInstance,
+    saveConfig,
+    setDefaultInstance,
+    upsertInstance,
+} from "../../services/cli-config.js";
 import { parseTarget } from "../../services/deployment-target.js";
 import type { CliConfig, CommandContext, ParsedArgs } from "../../types.js";
 
@@ -25,4 +30,104 @@ export async function runInstanceAdd(
     await saveConfig(configPath, nextConfig);
     context.stdout.write(`Added ${target} instance ${name}.\n`);
     return 0;
+}
+
+export function runInstanceList(config: CliConfig, context: CommandContext): number {
+    const instances = Object.entries(config.instances).sort(([left], [right]) =>
+        left.localeCompare(right),
+    );
+    if (instances.length === 0) {
+        context.stdout.write("No configured instances.\n");
+        return 0;
+    }
+
+    context.stdout.write("Configured instances:\n");
+    for (const [name, instance] of instances) {
+        const defaultLabel = name === config.defaultInstance ? " (default)" : "";
+        context.stdout.write(
+            `- ${name}${defaultLabel}: ${instance.target} ${instance.url}\n`,
+        );
+    }
+    return 0;
+}
+
+export function runInstanceShow(
+    config: CliConfig,
+    parsed: ParsedArgs,
+    context: CommandContext,
+): number {
+    const name = parsed.positionals[0] ?? config.defaultInstance;
+    if (!name) {
+        throw new Error("No instance selected. Specify a name or add an instance first.");
+    }
+    const instance = config.instances[name];
+    if (!instance) {
+        throw new Error(`Unknown instance: ${name}`);
+    }
+
+    const defaultLabel = name === config.defaultInstance ? " (default)" : "";
+    context.stdout.write(`Instance ${name}${defaultLabel}\n`);
+    context.stdout.write(`Target: ${instance.target}\n`);
+    context.stdout.write(`API URL: ${instance.url}\n`);
+    writeOptionalValue(context, "Client URL", instance.clientUrl);
+    writeOptionalValue(context, "Project directory", instance.projectDirectory);
+    writeOptionalValue(context, "Compose file", instance.composeFile);
+    writeOptionalList(context, "Compose files", instance.composeFiles);
+    writeOptionalList(context, "Compose profiles", instance.composeProfiles);
+    writeOptionalValue(context, "Environment file", instance.envFile);
+    writeOptionalValue(context, "Project name", instance.projectName);
+    return 0;
+}
+
+export async function runInstanceUse(
+    configPath: string,
+    config: CliConfig,
+    parsed: ParsedArgs,
+    context: CommandContext,
+): Promise<number> {
+    const name = requireInstanceName(parsed);
+    await saveConfig(configPath, setDefaultInstance(config, name));
+    context.stdout.write(`Default instance set to ${name}.\n`);
+    return 0;
+}
+
+export async function runInstanceRemove(
+    configPath: string,
+    config: CliConfig,
+    parsed: ParsedArgs,
+    context: CommandContext,
+): Promise<number> {
+    const name = requireInstanceName(parsed);
+    await saveConfig(configPath, removeInstance(config, name));
+    context.stdout.write(`Unregistered instance ${name}.\n`);
+    context.stdout.write("Deployment resources were not removed.\n");
+    return 0;
+}
+
+function requireInstanceName(parsed: ParsedArgs): string {
+    const name = parsed.positionals[0];
+    if (!name) {
+        throw new Error("Instance name is required.");
+    }
+    return name;
+}
+
+function writeOptionalValue(
+    context: CommandContext,
+    label: string,
+    value: string | undefined,
+): void {
+    if (value !== undefined) {
+        context.stdout.write(`${label}: ${value}\n`);
+    }
+}
+
+function writeOptionalList(
+    context: CommandContext,
+    label: string,
+    value: string[] | undefined,
+): void {
+    if (value !== undefined) {
+        context.stdout.write(`${label}: ${value.join(", ")}\n`);
+    }
 }

--- a/apps/cli/src/commands/instance/index.ts
+++ b/apps/cli/src/commands/instance/index.ts
@@ -1,7 +1,13 @@
 import { Command } from "commander";
 import type { CommandContext } from "../../types.js";
 import { loadCliState, parsedArgs, type SetExitCode } from "../shared.js";
-import { runInstanceAdd } from "./action.js";
+import {
+    runInstanceAdd,
+    runInstanceList,
+    runInstanceRemove,
+    runInstanceShow,
+    runInstanceUse,
+} from "./action.js";
 
 export function createInstanceCommand(
     context: CommandContext,
@@ -10,6 +16,56 @@ export function createInstanceCommand(
     const instance = new Command("instance")
         .description("Manage configured EUDIPLO instances")
         .helpCommand(true);
+    instance
+        .command("list")
+        .alias("ls")
+        .description("List configured EUDIPLO instances")
+        .action(async () => {
+            const { config } = await loadCliState(context);
+            setExitCode(runInstanceList(config, context));
+        });
+    instance
+        .command("show [name]")
+        .description("Show configured instance details")
+        .action(async (name) => {
+            const { config } = await loadCliState(context);
+            setExitCode(
+                runInstanceShow(
+                    config,
+                    parsedArgs("instance", "show", name ? [name] : [], {}),
+                    context,
+                ),
+            );
+        });
+    instance
+        .command("use <name>")
+        .description("Set the default EUDIPLO instance")
+        .action(async (name) => {
+            const { configPath, config } = await loadCliState(context);
+            setExitCode(
+                await runInstanceUse(
+                    configPath,
+                    config,
+                    parsedArgs("instance", "use", [name], {}),
+                    context,
+                ),
+            );
+        });
+    instance
+        .command("remove <name>")
+        .alias("rm")
+        .description("Unregister an EUDIPLO instance")
+        .action(async (name) => {
+            const { configPath, config } = await loadCliState(context);
+            setExitCode(
+                await runInstanceRemove(
+                    configPath,
+                    config,
+                    parsedArgs("instance", "remove", [name], {}),
+                    context,
+                ),
+            );
+        });
     instance
         .command("add <name>")
         .description("Register an existing EUDIPLO deployment")

--- a/apps/cli/src/runtime.ts
+++ b/apps/cli/src/runtime.ts
@@ -1,5 +1,9 @@
 import { isSea } from "node:sea";
 import { Command, CommanderError } from "commander";
+import {
+    createCompletionCandidatesCommand,
+    createCompletionCommand,
+} from "./commands/completion/index.js";
 import { createConfigCommand } from "./commands/config/index.js";
 import { createDemoCommand } from "./commands/demo/index.js";
 import { createDeploymentCommands } from "./commands/deployment/index.js";
@@ -56,6 +60,10 @@ function createProgram(
     program.addCommand(createDoctorCommand(context, setExitCode));
     program.addCommand(createStatusCommand(context, setExitCode));
     program.addCommand(createVersionCommand(context, setExitCode));
+    program.addCommand(createCompletionCommand(context, setExitCode));
+    program.addCommand(createCompletionCandidatesCommand(context, setExitCode), {
+        hidden: true,
+    });
     program.action(function showRootHelp() {
         this.outputHelp();
     });

--- a/apps/cli/src/services/cli-config.ts
+++ b/apps/cli/src/services/cli-config.ts
@@ -71,6 +71,31 @@ export function upsertInstance(
     };
 }
 
+export function setDefaultInstance(config: CliConfig, name: string): CliConfig {
+    if (!Object.hasOwn(config.instances, name)) {
+        throw new Error(`Unknown instance: ${name}`);
+    }
+    return { ...config, defaultInstance: name };
+}
+
+export function removeInstance(config: CliConfig, name: string): CliConfig {
+    if (!Object.hasOwn(config.instances, name)) {
+        throw new Error(`Unknown instance: ${name}`);
+    }
+    if (config.defaultInstance === name && Object.keys(config.instances).length > 1) {
+        throw new Error(
+            `Cannot remove default instance ${name}. Select another with: eudiplo instance use <name>`,
+        );
+    }
+
+    const instances = { ...config.instances };
+    delete instances[name];
+    return {
+        defaultInstance: config.defaultInstance === name ? undefined : config.defaultInstance,
+        instances,
+    };
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/apps/cli/test/runtime.test.ts
+++ b/apps/cli/test/runtime.test.ts
@@ -71,6 +71,8 @@ describe("EUDIPLO CLI", () => {
 
         expect(await runCli(["config"], context)).toBe(0);
         expect(output.stdout).toContain("Usage: eudiplo config [options] [command]");
+        expect(output.stdout).toContain("path");
+        expect(output.stdout).toContain("show [options]");
         expect(output.stdout).toContain("validate");
         expect(output.stdout).toContain("tenant");
         expect(output.stdout).not.toContain("tenant create");
@@ -184,6 +186,52 @@ describe("EUDIPLO CLI", () => {
 
         expect(code).toBe(0);
         expect(output.stdout).toContain("latest unavailable: npm registry returned HTTP 404");
+    });
+
+    it("generates completion scripts for supported shells", async () => {
+        const { context, output } = await createContext();
+        const expectations = {
+            bash: "complete -F _eudiplo_completion eudiplo",
+            zsh: "#compdef eudiplo",
+            fish: "complete -c eudiplo",
+            powershell: "Register-ArgumentCompleter -Native -CommandName eudiplo",
+        };
+
+        for (const [shell, marker] of Object.entries(expectations)) {
+            output.stdout = "";
+            expect(await runCli(["completion", shell], context)).toBe(0);
+            expect(output.stdout).toContain(marker);
+            expect(output.stdout).toContain("eudiplo _complete");
+        }
+    });
+
+    it("provides dynamic command, option, and choice completion candidates", async () => {
+        const { context, output } = await createContext();
+
+        expect(await runCli(["_complete"], context)).toBe(0);
+        expect(output.stdout).toContain("instance\n");
+        expect(output.stdout).toContain("completion\n");
+        expect(output.stdout).not.toContain("_complete\n");
+
+        output.stdout = "";
+        expect(await runCli(["_complete", "config"], context)).toBe(0);
+        expect(output.stdout).toContain("path\n");
+        expect(output.stdout).toContain("show\n");
+        expect(output.stdout).toContain("tenant\n");
+
+        output.stdout = "";
+        expect(await runCli(["_complete", "config", "show"], context)).toBe(0);
+        expect(output.stdout).toContain("--json\n");
+
+        output.stdout = "";
+        expect(await runCli(["_complete", "completion"], context)).toBe(0);
+        expect(output.stdout).toContain("bash\n");
+        expect(output.stdout).toContain("powershell\n");
+
+        output.stdout = "";
+        expect(await runCli(["_complete", "init", "--target"], context)).toBe(0);
+        expect(output.stdout).toContain("compose\n");
+        expect(output.stdout).toContain("external\n");
     });
 
     it("registers an external instance without storing secrets", async () => {
@@ -968,13 +1016,45 @@ describe("EUDIPLO CLI", () => {
         );
     });
 
-    it("rejects unknown config subcommands", async () => {
-        const { context, output } = await createContext();
+    it("prints the config path and shows validated config in text or JSON", async () => {
+        const { context, output, configPath } = await createContext();
+        await runCli(
+            [
+                "instance",
+                "add",
+                "production",
+                "--url",
+                "https://eudiplo.example.com",
+                "--client-url",
+                "https://client.eudiplo.example.com",
+            ],
+            context,
+        );
 
-        const code = await runCli(["config", "show"], context);
+        output.stdout = "";
+        expect(await runCli(["config", "path"], context)).toBe(0);
+        expect(output.stdout).toBe(`${configPath}\n`);
 
-        expect(code).toBe(1);
-        expect(output.stderr).toContain("too many arguments for 'config'");
+        output.stdout = "";
+        expect(await runCli(["config", "show"], context)).toBe(0);
+        expect(output.stdout).toContain(`Config: ${configPath}`);
+        expect(output.stdout).toContain("Default instance: production");
+        expect(output.stdout).toContain("- production (default)");
+        expect(output.stdout).toContain("  target: external");
+        expect(output.stdout).toContain("  clientUrl: https://client.eudiplo.example.com");
+
+        output.stdout = "";
+        expect(await runCli(["config", "show", "--json"], context)).toBe(0);
+        expect(JSON.parse(output.stdout)).toEqual({
+            defaultInstance: "production",
+            instances: {
+                production: {
+                    target: "external",
+                    url: "https://eudiplo.example.com",
+                    clientUrl: "https://client.eudiplo.example.com",
+                },
+            },
+        });
     });
 });
 

--- a/apps/cli/test/runtime.test.ts
+++ b/apps/cli/test/runtime.test.ts
@@ -107,6 +107,10 @@ describe("EUDIPLO CLI", () => {
 
         expect(await runCli(["instance"], context)).toBe(0);
         expect(output.stdout).toContain("Usage: eudiplo instance [options] [command]");
+        expect(output.stdout).toContain("list|ls");
+        expect(output.stdout).toContain("show [name]");
+        expect(output.stdout).toContain("use <name>");
+        expect(output.stdout).toContain("remove|rm <name>");
         expect(output.stdout).toContain("add [options] <name>");
 
         output.stdout = "";
@@ -199,6 +203,100 @@ describe("EUDIPLO CLI", () => {
             url: "https://eudiplo.example.com",
         });
         expect(JSON.stringify(config)).not.toContain("secret");
+    });
+
+    it("lists configured instances through the ls alias", async () => {
+        const { context, output } = await createContext();
+
+        expect(await runCli(["instance", "ls"], context)).toBe(0);
+        expect(output.stdout).toBe("No configured instances.\n");
+
+        await runCli(
+            ["instance", "add", "production", "--url", "https://eudiplo.example.com"],
+            context,
+        );
+        await runCli(
+            ["instance", "add", "alpha", "--url", "https://alpha.example.com"],
+            context,
+        );
+        output.stdout = "";
+
+        expect(await runCli(["instance", "ls"], context)).toBe(0);
+        expect(output.stdout).toBe(
+            "Configured instances:\n" +
+                "- alpha: external https://alpha.example.com\n" +
+                "- production (default): external https://eudiplo.example.com\n",
+        );
+    });
+
+    it("changes the default instance and shows its details", async () => {
+        const { context, output } = await createContext();
+        await runCli(
+            ["instance", "add", "production", "--url", "https://eudiplo.example.com"],
+            context,
+        );
+        await runCli(
+            [
+                "instance",
+                "add",
+                "staging",
+                "--url",
+                "https://staging.example.com",
+                "--client-url",
+                "https://client.staging.example.com",
+            ],
+            context,
+        );
+        output.stdout = "";
+
+        expect(await runCli(["instance", "use", "staging"], context)).toBe(0);
+        expect(output.stdout).toContain("Default instance set to staging.");
+
+        output.stdout = "";
+        expect(await runCli(["instance", "show"], context)).toBe(0);
+        expect(output.stdout).toContain("Instance staging (default)");
+        expect(output.stdout).toContain("Target: external");
+        expect(output.stdout).toContain("API URL: https://staging.example.com");
+        expect(output.stdout).toContain("Client URL: https://client.staging.example.com");
+    });
+
+    it("unregisters non-default and final instances without removing deployments", async () => {
+        const { context, output, configPath } = await createContext();
+        await runCli(
+            ["instance", "add", "production", "--url", "https://eudiplo.example.com"],
+            context,
+        );
+        await runCli(
+            ["instance", "add", "staging", "--url", "https://staging.example.com"],
+            context,
+        );
+
+        output.stdout = "";
+        expect(await runCli(["instance", "rm", "staging"], context)).toBe(0);
+        expect(output.stdout).toContain("Unregistered instance staging.");
+        expect(output.stdout).toContain("Deployment resources were not removed.");
+
+        output.stdout = "";
+        expect(await runCli(["instance", "remove", "production"], context)).toBe(0);
+        const config = JSON.parse(await readFile(configPath, "utf8"));
+        expect(config).toEqual({ instances: {} });
+    });
+
+    it("requires switching before unregistering the default instance", async () => {
+        const { context, output } = await createContext();
+        await runCli(
+            ["instance", "add", "production", "--url", "https://eudiplo.example.com"],
+            context,
+        );
+        await runCli(
+            ["instance", "add", "staging", "--url", "https://staging.example.com"],
+            context,
+        );
+        output.stdout = "";
+
+        expect(await runCli(["instance", "remove", "production"], context)).toBe(1);
+        expect(output.stderr).toContain("Cannot remove default instance production");
+        expect(output.stderr).toContain("eudiplo instance use <name>");
     });
 
     it("rejects compose-only commands for external instances", async () => {

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -130,6 +130,10 @@ register the public API URL:
 
 ```bash
 eudiplo instance add production --url https://eudiplo.example.com
+eudiplo instance ls
+eudiplo instance show production
+eudiplo instance use production
+eudiplo instance remove old-production
 ```
 
 Instance metadata is stored in the user's EUDIPLO CLI config directory, not in

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -167,6 +167,29 @@ HTTP(S) URLs, verifies the default instance points to a configured instance, and
 prints the configured instances. It does not require Docker or contact the
 deployment.
 
+Use `config path` to print the resolved CLI config file and `config show` to
+inspect its validated contents. The JSON form is suitable for scripts:
+
+```bash
+eudiplo config path
+eudiplo config show
+eudiplo config show --json
+```
+
+## Shell Completion
+
+Generate command, option, and enumerated-value completion for the current shell:
+
+```bash
+source <(eudiplo completion bash)
+source <(eudiplo completion zsh)
+eudiplo completion fish | source
+eudiplo completion powershell | Out-String | Invoke-Expression
+```
+
+Persist the generated script in the shell's normal completion directory to load
+it automatically in future sessions.
+
 ## Compose Driver Commands
 
 These commands are available only for `compose` instances:


### PR DESCRIPTION
## Description

Expands the EUDIPLO CLI with configuration and instance-management workflows:

- adds `instance list|ls`, `show`, `use`, and `remove|rm`
- marks and safely manages the default instance
- adds `config path` and validated `config show` output with `--json`
- adds dynamic completion generation for Bash, Zsh, Fish, and PowerShell
- updates CLI documentation and runtime coverage

Removal only unregisters CLI metadata and never deletes deployment resources. Removing the default is blocked until another default is selected, unless it is the final instance.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test improvements
- [ ] Build/CI changes

## Breaking Changes

None.

## Testing

- [x] CLI tests: 75 passed
- [x] CLI lint passed
- [x] TypeScript compilation passed
- [x] Bash and Zsh generated-script syntax checks passed
- [x] Pre-push `knip` validation passed

**Test Configuration**:

- Node.js version: repository environment
- OS: macOS

## Checklist

- [x] Changes are committed and pushed
- [x] Documentation updated
- [x] Tests added for the new behavior