### PR TITLE
fix(iso18013): read meta.doctype_value, the field the schema allows

### DIFF
--- a/apps/backend/src/verifier/iso18013/iso18013.service.spec.ts
+++ b/apps/backend/src/verifier/iso18013/iso18013.service.spec.ts
@@ -33,7 +33,7 @@ describe("Iso18013Service.createOffer per-request webhook override", () => {
                     credentials: [
                         {
                             format: "mso_mdoc",
-                            meta: { doctype: "eu.europa.ec.av.1" },
+                            meta: { doctype_value: "eu.europa.ec.av.1" },
                             claims: [],
                         },
                     ],

--- a/apps/backend/src/verifier/iso18013/iso18013.service.ts
+++ b/apps/backend/src/verifier/iso18013/iso18013.service.ts
@@ -137,10 +137,20 @@ export class Iso18013Service {
             );
         }
 
-        const docType = (mdocCred.meta as { doctype?: string })?.doctype;
+        // `doctype_value` is the field the OpenID4VP DCQL spec defines for
+        // mso_mdoc `meta`, and the only one CredentialQueryMsoMdocSchema
+        // accepts: it is .strict() and marks doctype_value required.
+        //
+        // Reading the non-spec `doctype` here left no valid configuration: one
+        // carrying it is rejected on write by the strict schema, and one
+        // without it fails every ISO 18013-7 offer. The rest of the codebase
+        // already treats doctype_value as authoritative — see
+        // schema-metadata-submission.service.ts, which only ever writes it.
+        const docType = (mdocCred.meta as { doctype_value?: string })
+            ?.doctype_value;
         if (!docType) {
             throw new BadRequestException(
-                `Presentation config "${requestId}" mso_mdoc credential has no meta.doctype`,
+                `Presentation config "${requestId}" mso_mdoc credential has no meta.doctype_value`,
             );
         }
 


### PR DESCRIPTION
## 📝 Description

The ISO 18013-7 offer builder reads `meta.doctype`, which the OpenID4VP DCQL
spec does not define for `mso_mdoc`. Since the presentation config schema became
strict, that leaves **no valid configuration**:

| Config | Result |
| --- | --- |
| carries `doctype` | rejected on write: `unrecognized key(s) "doctype"` |
| omits `doctype` | every ISO 18013-7 offer 400s: `... has no meta.doctype` |

On 6.x the same mismatch already breaks configs created through the EUDIPLO
client, which writes the conformant field:

```ts
// apps/client/.../issuer-metadata.service.ts
cred.meta = { doctype_value: selection.credential.doctype };
```

so only hand-written configs carrying the non-spec key work — which may explain
why this reproduces for some setups and not others.

This reads `doctype_value`, which `CredentialQueryMsoMdocSchema` marks required,
so every config writable under 7.x has it. It also aligns the offer builder with
the rest of the codebase: `schema-metadata-submission.service.ts` already treats
`doctype_value` as authoritative and only ever writes it.

Discussed with @cre8 on Discord.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 💥 Breaking Changes (if applicable)

None for any configuration writable under 7.x, since the schema requires
`doctype_value`.

Worth flagging explicitly: **no compatibility fallback to `doctype` is
included**, on the assumption you would rather migrate than accept both shapes —
the same posture 7.0 took with `trusted_authorities`,
`walletProviderTrustLists` and `webhook`. A pre-7.x row carrying only the
non-spec key would now fail. Happy to add a read fallback if you prefer.

## 🧪 Testing

- [x] Unit tests pass
- [x] Integration tests pass
- [x] E2E tests pass
- [ ] Manual testing performed

The existing spec fixture used `meta: { doctype: ... }`, so the suite passed
while the flow was broken; updated to `doctype_value` in this PR.

**Test Configuration**:

- Node.js version: as shipped in the backend image
- OS: Linux (Docker)
- Test environment: suite run on 7.2.0 with this change (26 files, 129 tests).
  `apps/backend/src/verifier/iso18013/` is byte-identical between v7.2.0 and
  `main`, so it applies to the same code; relying on CI here for `main`.

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

On documentation: if you want the `doctype` → `doctype_value` change called out
in the migration guide, say the word and I'll add it.

## 📋 Additional Notes

Found upgrading a real 6.1 deployment to 7.2.0 and resyncing Age Verification
presentation configs — the write failed with `unrecognized key(s) "doctype"`,
while dropping the key would have broken every DC API offer.
