### PR TITLE
fix(db): add the session columns that no migration ever created

### DIFF
--- a/apps/backend/src/database/migrations/1778000000000-AddMissingSessionColumns.ts
+++ b/apps/backend/src/database/migrations/1778000000000-AddMissingSessionColumns.ts
@@ -1,0 +1,60 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+/**
+ * Adds two `session` columns that exist on SessionEntity but that no migration
+ * ever created:
+ *
+ * - `responseEncryptionPrivateJwk`, added to the entity in #894 (7.0.0).
+ *   Without it, `POST /api/verifier/offer` fails with
+ *   `QueryFailedError: column Session.responseEncryptionPrivateJwk does not exist`.
+ * - `authorizationServerId`, the same omission on the issuance path.
+ *
+ * Fresh installs come up with `DB_SYNCHRONIZE=true`, so TypeORM creates the
+ * columns and the gap is invisible there. Deployments that upgrade with
+ * migrations only — the setting `data-source.ts` hardcodes for production —
+ * end up with a schema the code cannot query.
+ *
+ * Idempotent, so it is a no-op where synchronize already created them.
+ */
+export class AddMissingSessionColumns1778000000000
+    implements MigrationInterface
+{
+    name = "AddMissingSessionColumns1778000000000";
+
+    private readonly columns = [
+        new TableColumn({
+            name: "responseEncryptionPrivateJwk",
+            type: "text",
+            isNullable: true,
+        }),
+        new TableColumn({
+            name: "authorizationServerId",
+            type: "varchar",
+            isNullable: true,
+        }),
+    ];
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable("session");
+        if (!table) {
+            console.log("[Migration] session table not found — skipping.");
+            return;
+        }
+
+        for (const column of this.columns) {
+            if (table.columns.some((c) => c.name === column.name)) continue;
+            await queryRunner.addColumn("session", column);
+            console.log(`[Migration] Added ${column.name} to session.`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable("session");
+        if (!table) return;
+
+        for (const column of this.columns) {
+            if (!table.columns.some((c) => c.name === column.name)) continue;
+            await queryRunner.dropColumn("session", column.name);
+        }
+    }
+}

--- a/apps/backend/src/database/migrations/index.ts
+++ b/apps/backend/src/database/migrations/index.ts
@@ -43,3 +43,4 @@ export { AddRootExternalKeyIdToKeyChain1774000000000 } from "./1774000000000-Add
 export { AddNotificationEndpointEnabledToIssuanceConfig1775000000000 } from "./1775000000000-AddNotificationEndpointEnabledToIssuanceConfig";
 export { AddStatusListVersionAndUniqueConstraint1776000000000 } from "./1776000000000-AddStatusListVersionAndUniqueConstraint";
 export { AddConfigResourceMetadata1777000000000 } from "./1777000000000-AddConfigResourceMetadata";
+export { AddMissingSessionColumns1778000000000 } from "./1778000000000-AddMissingSessionColumns";


### PR DESCRIPTION
## 📝 Description

Two columns exist on `SessionEntity` but **no migration ever creates them**:

| Column | Introduced | Path affected |
| --- | --- | --- |
| `responseEncryptionPrivateJwk` | #894 (7.0.0) | verification — breaks `POST /api/verifier/offer` |
| `authorizationServerId` | — | issuance |

Fresh installs come up with `DB_SYNCHRONIZE=true`, so TypeORM creates the
columns and the gap is invisible. Deployments that upgrade **with migrations
only** — the setting `data-source.ts` hardcodes (`synchronize: false`) — end up
with a schema the code cannot query:

```
QueryFailedError: column Session.responseEncryptionPrivateJwk does not exist
POST /api/verifier/offer → 500
```

This adds one idempotent migration for both, guarded on
`table.columns.some(...)` like the surrounding ones, so it is a no-op where
`synchronize` already created them.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 💥 Breaking Changes (if applicable)

None.

- **Database**: migration included (`1778000000000-AddMissingSessionColumns`),
  idempotent, no manual steps. It only adds two nullable columns.

Numbered `1778000000000`, the next free slot above `1777000000000`. While
picking it: `1774000000000` is used by **two** migrations
(`AddReaderAuthToPresentationConfig` and `AddRootExternalKeyIdToKeyChain`) and
`1776000000000` by two more. TypeORM orders on that prefix, so the tie-break
currently depends on directory read order — harmless while those pairs are
independent, but happy to open a separate issue if useful.

## 🧪 Testing

- [x] Unit tests pass
- [x] Integration tests pass
- [x] E2E tests pass
- [x] Manual testing performed

Applied to a real database upgraded from 6.1: the migration added both columns,
the startup log showed no errors, and `POST /api/verifier/offer` — which failed
with the error above — succeeded afterwards. Re-running is a no-op.

**Test Configuration**:

- Node.js version: as shipped in the backend image
- OS: Linux (Docker, DigitalOcean droplet)
- Test environment: multi-tenant deployment, `DB_TYPE=postgres`,
  `DB_SYNCHRONIZE=false`, Postgres 16

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

On tests: the repo has no migration-level test harness that I could find, and
the fix is verified by the real upgrade described above. Glad to add one if
there's a pattern you'd like followed.

## 📋 Additional Notes

Found upgrading a real 6.1 deployment to 7.2.0 and running a verification.
Comparing applied migrations against the target tag showed nothing missing — the
migrations are consistent with each other; it is the entity that moved ahead of
them. Checked the rest of the `session` table column by column against the
entity: these two are the only ones missing.
