### PR TITLE
fix(webhook): allow presentation:manage to manage webhook endpoints

### DIFF
--- a/apps/backend/src/issuer/configuration/webhook-endpoint/webhook-endpoint.controller.ts
+++ b/apps/backend/src/issuer/configuration/webhook-endpoint/webhook-endpoint.controller.ts
@@ -19,8 +19,13 @@ import { UpdateWebhookEndpointDto } from "./dto/update-webhook-endpoint.dto";
 import { WebhookEndpointEntity } from "./entities/webhook-endpoint.entity";
 import { WebhookEndpointService } from "./webhook-endpoint.service";
 
+// Webhook endpoints are referenced from both sides: issuance configs and,
+// since 7.0 replaced the inline `webhook` payload with `webhookEndpointId`,
+// presentation configs too. Gating them on issuance alone meant a
+// verification-only tenant could not register the webhook its own presentation
+// config needs. RolesGuard is OR, so either role grants access.
 @ApiTags("Issuer")
-@Secured([Role.Issuances])
+@Secured([Role.Issuances, Role.Presentations])
 @Controller("issuer/webhook-endpoints")
 export class WebhookEndpointController {
     constructor(private readonly service: WebhookEndpointService) {}


### PR DESCRIPTION
## 📝 Description

Webhook endpoints are referenced from **both** sides: issuance configs, and —
since 7.0 replaced the inline `webhook` payload with `webhookEndpointId` —
presentation configs too. The resource was gated on `issuance:manage` alone, so
a verification-only tenant (`presentation:manage` + `presentation:request`)
could not register the webhook its own presentation config needs.

```diff
-@Secured([Role.Issuances])
+@Secured([Role.Issuances, Role.Presentations])
```

`RolesGuard` evaluates required roles with `.some()`, so this grants access from
either side without widening what `issuance:manage` already covers. Tenant
isolation is unchanged — every query in the service filters on `tenantId`, so a
presentation role reaches only its own tenant's endpoints.

This is option 1 from the issue, as suggested there.

Fixes #956

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 💥 Breaking Changes (if applicable)

None. The change only widens who may call an existing endpoint; URLs, payloads
and behaviour are unchanged.

## 🧪 Testing

- [x] Unit tests pass
- [x] Integration tests pass
- [x] E2E tests pass
- [x] Manual testing performed

Reproduced the 403 on a 7.2.0 deployment with a client holding only
`presentation:manage` + `presentation:request` (see the issue for the captured
request/response), then confirmed the same call succeeds with this change.

**Test Configuration**:

- Node.js version: as shipped in the backend image
- OS: Linux (Docker)
- Test environment: multi-tenant staging deployment, `DB_TYPE=postgres`

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

On the two unchecked boxes: the role list is documented by the decorator itself,
and the existing suite has no coverage of role gating on this controller — happy
to add a guard-level test if you'd like one.

## 📋 Additional Notes

You mentioned the resource arguably belongs in the **verifier** module with a
matching URL, and that merging it with attribute providers may or may not cause
conflicts later.

I left both out on purpose: the move is a breaking change to a public URL, and
the merge question is still open on your side. Bundling either would make a
one-line bug fix wait on a design discussion. Happy to follow up with the move
as its own PR once you've settled where it should live — and whether
`issuance:manage` alone should keep covering attribute providers.
