### PR TITLE
fix: use Algolia env vars for docs search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,3 +87,9 @@ AUTH_CLIENT_SECRET=your-secure-secret
 
 # If set, HTML base href will be configured to this value (e.g., for reverse proxy setups).
 # CLIENT_BASE_HREF=/your-base-path/
+
+# Algolia DocSearch configuration for the docs site.
+# Use the search-only API key from your Algolia index, not an admin key.
+#ALGOLIA_APP_ID=your-algolia-app-id
+#ALGOLIA_SEARCH_API_KEY=your-search-only-api-key
+#ALGOLIA_INDEX_NAME=eudiplo

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -215,6 +215,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build documentation
+        env:
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_SEARCH_API_KEY: ${{ secrets.ALGOLIA_SEARCH_API_KEY }}
+          ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
         run: pnpm --filter @eudiplo/docs run build
 
       - name: Upload built documentation
@@ -249,6 +253,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build generated docs content
+        env:
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_SEARCH_API_KEY: ${{ secrets.ALGOLIA_SEARCH_API_KEY }}
+          ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
         run: pnpm --filter @eudiplo/docs run build
 
       - name: Deploy website to Cloudflare Pages preview
@@ -256,6 +264,9 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_PAGES_BRANCH: preview
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_SEARCH_API_KEY: ${{ secrets.ALGOLIA_SEARCH_API_KEY }}
+          ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
         run: |
           test -n "$CLOUDFLARE_API_TOKEN" || { echo "CLOUDFLARE_API_TOKEN is not configured"; exit 1; }
           test -n "$CLOUDFLARE_ACCOUNT_ID" || { echo "CLOUDFLARE_ACCOUNT_ID is not configured"; exit 1; }
@@ -266,6 +277,9 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_PAGES_BRANCH: preview
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_SEARCH_API_KEY: ${{ secrets.ALGOLIA_SEARCH_API_KEY }}
+          ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
         run: |
           test -n "$CLOUDFLARE_API_TOKEN" || { echo "CLOUDFLARE_API_TOKEN is not configured"; exit 1; }
           test -n "$CLOUDFLARE_ACCOUNT_ID" || { echo "CLOUDFLARE_ACCOUNT_ID is not configured"; exit 1; }


### PR DESCRIPTION
## Summary
- pass Algolia DocSearch values from GitHub Actions secrets
- document required env vars in the repo example config
- keep docs builds compatible with Docusaurus env-based configuration

## Why
The docs site reads Algolia values from environment variables already, so this change avoids hardcoded secrets and makes the deployment configuration consistent with the repo's existing Docusaurus setup.

## Validation
- `pnpm --filter @eudiplo/docs typecheck`