### PR TITLE
feat(client): bulk detach and quick navigation for config portability resources

### DIFF
--- a/apps/client/src/app/config-portability/config-portability.component.html
+++ b/apps/client/src/app/config-portability/config-portability.component.html
@@ -42,8 +42,10 @@
         <mat-card-subtitle>Planning is read-only and always runs before apply.</mat-card-subtitle>
       </mat-card-header>
       <mat-card-content class="import-controls">
+        <label for="bundleInput" class="visually-hidden">Configuration bundle file</label>
         <input
           #bundleInput
+          id="bundleInput"
           type="file"
           accept="application/zip,.zip,application/json,.json"
           hidden
@@ -178,12 +180,48 @@
       @if (!resources.length) {
         <p class="muted">No resource ownership metadata has been recorded yet.</p>
       } @else {
+        @if (selected.size) {
+          <div class="bulk-actions">
+            <span class="muted">{{ selected.size }} selected</span>
+            <button mat-button (click)="detachSelected()" [disabled]="busy || !canApply">
+              <mat-icon>link_off</mat-icon>
+              Detach selected
+            </button>
+          </div>
+        }
         <table mat-table [dataSource]="resources">
+          <ng-container matColumnDef="select">
+            <th mat-header-cell *matHeaderCellDef>
+              <mat-checkbox
+                [checked]="allSelected"
+                [disabled]="busy || !canApply || !detachableResources.length"
+                aria-label="Select all detachable resources"
+                (change)="$event.checked ? selectAll() : deselectAll()"
+              ></mat-checkbox>
+            </th>
+            <td mat-cell *matCellDef="let item">
+              @if (item.ownership === 'file-managed') {
+                <mat-checkbox
+                  [checked]="isSelected(item)"
+                  [disabled]="busy || !canApply"
+                  [attr.aria-label]="'Select ' + item.kind + '/' + item.resourceId"
+                  (change)="$event.checked ? selectResource(item) : deselectResource(item)"
+                ></mat-checkbox>
+              }
+            </td>
+          </ng-container>
           <ng-container matColumnDef="resource">
             <th mat-header-cell *matHeaderCellDef>Resource</th>
             <td mat-cell *matCellDef="let item">
-              <strong>{{ item.kind }}</strong
-              >/{{ item.resourceId }}
+              @if (resourceLink(item); as link) {
+                <a [routerLink]="link"
+                  ><strong>{{ item.kind }}</strong
+                  >/{{ item.resourceId }}</a
+                >
+              } @else {
+                <strong>{{ item.kind }}</strong
+                >/{{ item.resourceId }}
+              }
             </td>
           </ng-container>
           <ng-container matColumnDef="ownership">
@@ -203,6 +241,16 @@
           <ng-container matColumnDef="actions">
             <th mat-header-cell *matHeaderCellDef></th>
             <td mat-cell *matCellDef="let item">
+              @if (resourceLink(item); as link) {
+                <button
+                  mat-icon-button
+                  [routerLink]="link"
+                  matTooltip="View resource"
+                  [attr.aria-label]="'View ' + item.kind + '/' + item.resourceId"
+                >
+                  <mat-icon>open_in_new</mat-icon>
+                </button>
+              }
               <button
                 mat-button
                 (click)="detach(item)"

--- a/apps/client/src/app/config-portability/config-portability.component.scss
+++ b/apps/client/src/app/config-portability/config-portability.component.scss
@@ -45,6 +45,13 @@ mat-card-content {
   overflow-x: auto;
 }
 
+.bulk-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
 table {
   width: 100%;
 }
@@ -56,6 +63,18 @@ table {
 .key-file {
   margin-left: 0.75rem;
   color: var(--mat-sys-on-surface-variant);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .issue {

--- a/apps/client/src/app/config-portability/config-portability.component.ts
+++ b/apps/client/src/app/config-portability/config-portability.component.ts
@@ -1,8 +1,10 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
@@ -10,6 +12,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { getApiErrorMessage } from '../utils/error-message';
 import { JwtService } from '../services/jwt.service';
 import {
@@ -26,8 +29,10 @@ import {
   imports: [
     CommonModule,
     FormsModule,
+    RouterLink,
     MatButtonModule,
     MatCardModule,
+    MatCheckboxModule,
     MatChipsModule,
     MatFormFieldModule,
     MatIconModule,
@@ -35,6 +40,7 @@ import {
     MatSelectModule,
     MatSnackBarModule,
     MatTableModule,
+    MatTooltipModule,
   ],
   templateUrl: './config-portability.component.html',
   styleUrl: './config-portability.component.scss',
@@ -42,13 +48,14 @@ import {
 })
 export class ConfigPortabilityComponent implements OnInit {
   readonly planColumns = ['resource', 'version', 'action', 'issues'];
-  readonly resourceColumns = ['resource', 'ownership', 'generation', 'source', 'actions'];
+  readonly resourceColumns = ['select', 'resource', 'ownership', 'generation', 'source', 'actions'];
   mode: ConfigImportMode = 'upsert';
   bundle?: ConfigBundle;
   bundleArchive?: File;
   bundleFileName = '';
   plan?: ConfigImportPlan;
   resources: ConfigResourceMetadata[] = [];
+  selected = new Set<string>();
   busy = false;
 
   constructor(
@@ -159,8 +166,106 @@ export class ConfigPortabilityComponent implements OnInit {
     }
     await this.run(async () => {
       await this.portability.detach(resource.kind, resource.resourceId);
+      this.selected.delete(this.resourceKey(resource));
       await this.refreshResources();
     }, 'Could not detach resource');
+  }
+
+  resourceKey(resource: ConfigResourceMetadata): string {
+    return `${resource.kind}/${resource.resourceId}`;
+  }
+
+  /** Route to view the resource, or null when the kind has no dedicated detail page. */
+  resourceLink(resource: ConfigResourceMetadata): string[] | null {
+    const routesByKind: Partial<Record<ConfigResourceMetadata['kind'], string>> = {
+      Tenant: '/tenants',
+      Client: '/clients',
+      KeyChain: '/keys',
+      CredentialConfig: '/credential-config',
+      PresentationConfig: '/presentation-config',
+      AttributeProvider: '/attribute-providers',
+      WebhookEndpoint: '/webhook-endpoints',
+      TrustList: '/trust-list',
+      StatusList: '/status-lists',
+    };
+    const base = routesByKind[resource.kind];
+    if (base) return [base, resource.resourceId];
+
+    const singletonRoutesByKind: Partial<Record<ConfigResourceMetadata['kind'], string>> = {
+      IssuanceConfig: '/issuance-config',
+      RegistrarConfig: '/registrar',
+      KmsConfig: '/kms',
+    };
+    const singleton = singletonRoutesByKind[resource.kind];
+    return singleton ? [singleton] : null;
+  }
+
+  isSelected(resource: ConfigResourceMetadata): boolean {
+    return this.selected.has(this.resourceKey(resource));
+  }
+
+  selectResource(resource: ConfigResourceMetadata): void {
+    this.selected.add(this.resourceKey(resource));
+  }
+
+  deselectResource(resource: ConfigResourceMetadata): void {
+    this.selected.delete(this.resourceKey(resource));
+  }
+
+  get detachableResources(): ConfigResourceMetadata[] {
+    return this.resources.filter((resource) => resource.ownership === 'file-managed');
+  }
+
+  get allSelected(): boolean {
+    const detachable = this.detachableResources;
+    return detachable.length > 0 && detachable.every((resource) => this.isSelected(resource));
+  }
+
+  selectAll(): void {
+    for (const resource of this.detachableResources) {
+      this.selectResource(resource);
+    }
+  }
+
+  deselectAll(): void {
+    this.selected.clear();
+  }
+
+  async detachSelected(): Promise<void> {
+    const targets = this.resources.filter((resource) => this.isSelected(resource));
+    if (!targets.length) return;
+    if (
+      !globalThis.confirm(
+        `Detach ${targets.length} resource(s)? They will become editable through the API and UI.`
+      )
+    ) {
+      return;
+    }
+    this.busy = true;
+    try {
+      const failures: string[] = [];
+      for (const resource of targets) {
+        try {
+          await this.portability.detach(resource.kind, resource.resourceId);
+          this.selected.delete(this.resourceKey(resource));
+        } catch (error) {
+          failures.push(`${this.resourceKey(resource)}: ${getApiErrorMessage(error, 'failed')}`);
+        }
+      }
+      await this.refreshResources();
+      const succeeded = targets.length - failures.length;
+      if (failures.length) {
+        this.snackBar.open(
+          `Detached ${succeeded} of ${targets.length} resource(s). Failed: ${failures.join('; ')}`,
+          'Close',
+          { duration: 8000 }
+        );
+      } else {
+        this.snackBar.open(`Detached ${succeeded} resource(s)`, 'Close', { duration: 3000 });
+      }
+    } finally {
+      this.busy = false;
+    }
   }
 
   onModeChange(): void {
@@ -180,6 +285,10 @@ export class ConfigPortabilityComponent implements OnInit {
   private async refreshResources(): Promise<void> {
     try {
       this.resources = await this.portability.listResources();
+      const validKeys = new Set(this.resources.map((resource) => this.resourceKey(resource)));
+      for (const key of this.selected) {
+        if (!validKeys.has(key)) this.selected.delete(key);
+      }
     } catch (error) {
       this.snackBar.open(getApiErrorMessage(error, 'Could not load resource ownership'), 'Close', {
         duration: 5000,


### PR DESCRIPTION
## 📝 Description

Improves the "Resource ownership" table on the Configuration Portability page:

- Select multiple file-managed resources via checkboxes (with a "select all" header checkbox) and detach them in a single action.
- Bulk detach reports partial success/failure (e.g. "Detached 3 of 4 resource(s)") instead of a single generic error.
- Stale selections are pruned after each refresh so the "N selected" count doesn't drift.
- Each resource row now links to its detail page (and a matching icon-button action) so it's quick to jump to the resource being managed.
- Fixed a pre-existing accessibility issue: the hidden bundle file input lacked an associated label.

## 🔄 Type of Change

- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing

- [x] Manual testing performed (client dev server)
- Linting/formatting/knip run via pre-commit hooks, all passing.

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
