### PR TITLE
feat(client): add contextual documentation links

### DIFF
--- a/apps/backend/src/verifier/presentations/schemas/presentation-config.schema.ts
+++ b/apps/backend/src/verifier/presentations/schemas/presentation-config.schema.ts
@@ -305,6 +305,7 @@ export const PresentationConfigCreateSchema = z
         ),
         transaction_data: z
             .array(TransactionDataSchema)
+            .nullable()
             .optional()
             .describe("Optional transaction data descriptors."),
         registration_cert: RegistrationCertificateRequestSchema.nullable()

--- a/apps/client/src/app/app.component.html
+++ b/apps/client/src/app/app.component.html
@@ -21,12 +21,7 @@
         <mat-icon>business</mat-icon>
         <span>Instance: {{ apiService.getBaseUrl() }}</span>
       </button>
-      <a
-        mat-menu-item
-        href="https://openwallet-foundation.github.io/eudiplo/docs/main/"
-        target="_blank"
-        rel="noopener"
-      >
+      <a mat-menu-item href="https://docs.eudiplo.dev/" target="_blank" rel="noopener">
         <mat-icon>help</mat-icon>
         Documentation
       </a>

--- a/apps/client/src/app/config-portability/config-portability.component.html
+++ b/apps/client/src/app/config-portability/config-portability.component.html
@@ -4,9 +4,20 @@
       <h2>Configuration Portability</h2>
       <p>Export, validate, migrate, and import tenant configuration as code.</p>
     </div>
-    @if (busy) {
-      <mat-spinner diameter="32"></mat-spinner>
-    }
+    <div fxLayout="row" fxLayoutAlign="center center" fxLayoutGap="12px">
+      <a
+        mat-stroked-button
+        href="https://docs.eudiplo.dev/architecture/configuration-model"
+        target="_blank"
+        rel="noopener"
+      >
+        <mat-icon>open_in_new</mat-icon>
+        Documentation
+      </a>
+      @if (busy) {
+        <mat-spinner diameter="32"></mat-spinner>
+      }
+    </div>
   </div>
 
   <div class="card-grid">

--- a/apps/client/src/app/dashboard/dashboard.component.html
+++ b/apps/client/src/app/dashboard/dashboard.component.html
@@ -580,12 +580,7 @@
     </mat-card-header>
     <mat-card-content>
       <div class="resource-links" fxLayout="row wrap" fxLayoutGap="16px">
-        <a
-          mat-stroked-button
-          href="https://openwallet-foundation.github.io/eudiplo/docs/latest/"
-          target="_blank"
-          rel="noopener"
-        >
+        <a mat-stroked-button href="https://docs.eudiplo.dev/" target="_blank" rel="noopener">
           <mat-icon>description</mat-icon> Documentation
         </a>
         <a mat-stroked-button [href]="currentBaseUrl + '/api-docs'" target="_blank" rel="noopener">

--- a/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.html
+++ b/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.html
@@ -15,6 +15,16 @@
         JSON View
       </button>
 
+      <a
+        mat-stroked-button
+        href="https://docs.eudiplo.dev/issuance/credential-configuration"
+        target="_blank"
+        rel="noopener"
+      >
+        <mat-icon>open_in_new</mat-icon>
+        Documentation
+      </a>
+
       <!-- Predefined Configs Menu -->
       @if (create) {
         <button

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.html
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.html
@@ -9,6 +9,15 @@
         <mat-icon>code</mat-icon>
         JSON View
       </button>
+      <a
+        mat-stroked-button
+        href="https://docs.eudiplo.dev/issuance/issuance-configuration"
+        target="_blank"
+        rel="noopener"
+      >
+        <mat-icon>open_in_new</mat-icon>
+        Documentation
+      </a>
       <button matIconButton [routerLink]="['../']" matTooltip="Back to list">
         <mat-icon>arrow_back</mat-icon>
       </button>

--- a/apps/client/src/app/presentation/presentation-config/presentation-create/presentation-create.component.html
+++ b/apps/client/src/app/presentation/presentation-config/presentation-create/presentation-create.component.html
@@ -15,6 +15,16 @@
         JSON View
       </button>
 
+      <a
+        mat-stroked-button
+        href="https://docs.eudiplo.dev/presentation/presentation-configuration"
+        target="_blank"
+        rel="noopener"
+      >
+        <mat-icon>open_in_new</mat-icon>
+        Documentation
+      </a>
+
       <!-- Predefined Configs Menu -->
       @if (create) {
         <button

--- a/apps/client/src/app/status-list-config/status-list-config.component.html
+++ b/apps/client/src/app/status-list-config/status-list-config.component.html
@@ -5,6 +5,15 @@
       <h2>Status List Configuration</h2>
       <p class="subtitle">Configure status list settings for newly issued credentials</p>
     </div>
+    <a
+      mat-stroked-button
+      href="https://docs.eudiplo.dev/issuance/status-management"
+      target="_blank"
+      rel="noopener"
+    >
+      <mat-icon>open_in_new</mat-icon>
+      Documentation
+    </a>
   </div>
 
   @if (isLoading) {

--- a/apps/client/src/app/trust-list/trust-list-edit/trust-list-edit.component.html
+++ b/apps/client/src/app/trust-list/trust-list-edit/trust-list-edit.component.html
@@ -5,9 +5,20 @@
   <!-- Header -->
   <div fxLayout="row" fxLayoutAlign="space-between center">
     <h2>{{ isEditMode ? 'Edit' : 'Create' }} Trust List</h2>
-    <button mat-icon-button routerLink="/trust-list" matTooltip="Back to Trust Lists">
-      <mat-icon>arrow_back</mat-icon>
-    </button>
+    <div fxLayout="row" fxLayoutGap="8px">
+      <a
+        mat-stroked-button
+        href="https://docs.eudiplo.dev/trust/trust-lists"
+        target="_blank"
+        rel="noopener"
+      >
+        <mat-icon>open_in_new</mat-icon>
+        Documentation
+      </a>
+      <button mat-icon-button routerLink="/trust-list" matTooltip="Back to Trust Lists">
+        <mat-icon>arrow_back</mat-icon>
+      </button>
+    </div>
   </div>
 
   @if (form) {

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -2,6 +2,7 @@ import {themes as prismThemes} from 'prism-react-renderer';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 import type * as Redirects from '@docusaurus/plugin-client-redirects';
+import 'dotenv/config';
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -26,6 +26,7 @@
     "@docusaurus/preset-classic": "3.10.2",
     "@docusaurus/theme-mermaid": "3.10.2",
     "@mdx-js/react": "^3.0.0",
+    "dotenv": "^17.4.2",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -567,6 +567,9 @@ importers:
       '@mdx-js/react':
         specifier: ^3.0.0
         version: 3.1.1(@types/react@19.2.18)(react@19.2.8)
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       prism-react-renderer:
         specifier: ^2.3.0
         version: 2.4.1(react@19.2.8)

--- a/schemas/PresentationConfigCreateDto.schema.json
+++ b/schemas/PresentationConfigCreateDto.schema.json
@@ -440,28 +440,35 @@
     },
     "transaction_data": {
       "description": "Optional transaction data descriptors.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "description": "Transaction data type identifier."
-          },
-          "credential_ids": {
-            "type": "array",
-            "items": {
-              "type": "string"
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Transaction data type identifier."
+              },
+              "credential_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Credential query ids this transaction data applies to."
+              }
             },
-            "description": "Credential query ids this transaction data applies to."
+            "required": [
+              "type",
+              "credential_ids"
+            ],
+            "additionalProperties": {}
           }
         },
-        "required": [
-          "type",
-          "credential_ids"
-        ],
-        "additionalProperties": {}
-      }
+        {
+          "type": "null"
+        }
+      ]
     },
     "registration_cert": {
       "description": "Optional registration certificate request settings.",


### PR DESCRIPTION
## Description

Add contextual documentation links throughout the client so users can open the relevant EUDIPLO guide from configuration workflows. Also allow explicit `null` for `transaction_data`, preserving the distinction between clearing a value and omitting it during updates.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update
- [x] 🧪 Test improvements

## Testing

- [x] Repository pre-commit formatting and lint checks pass
- [x] Repository pre-push Knip check passes
- [x] Angular client build passes
- [x] Client formatting check passes
- [x] Docs package typecheck passes
- [x] Focused backend schema validation passes for omitted, `null`, and populated `transaction_data`

## Changes

- Add documentation links to presentation, credential, issuance, status-list, trust-list, and configuration-portability workflows.
- Standardize global documentation links on `https://docs.eudiplo.dev/`.
- Update the generated presentation config schema to accept `transaction_data: null`.
- Declare the existing `dotenv/config` docs configuration dependency so repository dependency checks pass.

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing checks pass locally

## Additional Notes

The PR is non-breaking. On update, omitted fields retain their current values; explicit `null` clears nullable fields such as `transaction_data`.