### PR TITLE
Add external certificate support for key chains

### DIFF
--- a/apps/backend/src/crypto/key/key-chain-import.service.ts
+++ b/apps/backend/src/crypto/key/key-chain-import.service.ts
@@ -112,6 +112,10 @@ export class KeyChainImportService {
 
         let activeCertificate: string;
         if (normalizedCertificates && normalizedCertificates.length > 0) {
+            this.validateLeafCertificate(
+                normalizedCertificates[0],
+                activeMat.ref.publicJwk,
+            );
             activeCertificate = normalizedCertificates.join("\n");
         } else {
             const now = new Date();
@@ -334,6 +338,35 @@ export class KeyChainImportService {
         ) {
             throw new BadRequestException(
                 "Invalid rotation root certificate: certificate public key does not match the provided private key",
+            );
+        }
+    }
+
+    private validateLeafCertificate(
+        leafCertificatePem: string,
+        expectedPublicJwk: JWK,
+    ): void {
+        let certificate: X509Certificate;
+        try {
+            certificate = new X509Certificate(leafCertificatePem);
+        } catch (error) {
+            throw new BadRequestException(
+                `Invalid leaf certificate: ${String(error)}`,
+            );
+        }
+
+        const certificatePublicJwk = certificate.publicKey.export({
+            format: "jwk",
+        }) as JWK;
+
+        if (
+            !this.arePublicJwksEquivalent(
+                certificatePublicJwk,
+                expectedPublicJwk,
+            )
+        ) {
+            throw new BadRequestException(
+                "Invalid leaf certificate: certificate public key does not match the provided private key",
             );
         }
     }

--- a/apps/client/src/app/key-management/key-chain.service.ts
+++ b/apps/client/src/app/key-management/key-chain.service.ts
@@ -4,6 +4,7 @@ import {
   type KmsProvidersResponseDto,
   type KmsTenantConfigResponseDto,
   type KeyChainCreateDto,
+  type KeyChainImportDto,
   type KeyChainResponseDto,
   type KeyChainUpdateDto,
   keyChainControllerCreate,
@@ -15,6 +16,7 @@ import {
   keyChainControllerGetProviders,
   keyChainControllerGetProvidersHealth,
   keyChainControllerGetTenantKmsConfig,
+  keyChainControllerImport,
   keyChainControllerRotate,
   keyChainControllerUpdate,
   keyChainControllerUpdateTenantKmsConfig,
@@ -103,6 +105,12 @@ export class KeyChainService {
    */
   async create(data: KeyChainCreateDto): Promise<{ id: string }> {
     const response = await keyChainControllerCreate({ body: data });
+    return response.data as { id: string };
+  }
+
+  /** Import key material and an externally issued certificate chain. */
+  async import(data: KeyChainImportDto): Promise<{ id: string }> {
+    const response = await keyChainControllerImport({ body: data });
     return response.data as { id: string };
   }
 

--- a/apps/client/src/app/key-management/key-create-wizard/key-create-wizard.component.html
+++ b/apps/client/src/app/key-management/key-create-wizard/key-create-wizard.component.html
@@ -2,9 +2,20 @@
   <!-- Header -->
   <div fxLayout="row" fxLayoutAlign="space-between center" class="wizard-header">
     <h2>Create Key</h2>
-    <button mat-icon-button [routerLink]="['../']" matTooltip="Cancel">
-      <mat-icon>close</mat-icon>
-    </button>
+    <div fxLayout="row" fxLayoutGap="8px">
+      <a
+        mat-stroked-button
+        href="https://docs.eudiplo.dev/trust/key-chains"
+        target="_blank"
+        rel="noopener"
+      >
+        <mat-icon>open_in_new</mat-icon>
+        Documentation
+      </a>
+      <button mat-icon-button [routerLink]="['../']" matTooltip="Cancel">
+        <mat-icon>close</mat-icon>
+      </button>
+    </div>
   </div>
 
   <mat-stepper #stepper linear fxFlex>
@@ -135,7 +146,7 @@
           <div class="step-description">
             <h3>How do you want to get your access certificate?</h3>
             <p class="hint">
-              Choose self-signed for development or registrar enrollment for production.
+              Choose generated certificates, an external CA chain, or a standalone certificate.
             </p>
           </div>
 
@@ -222,9 +233,18 @@
                 This will create a key and enroll it with the registrar to obtain a trusted
                 certificate.
               </p>
+            } @else if (selectedUsage === 'access' && isExternalCertificate) {
+              <p class="hint">
+                This will import your externally issued access certificate and matching key.
+              </p>
             } @else if (selectedUsage === 'access') {
               <p class="hint">
                 This will create a self-signed access certificate for wallet communication.
+              </p>
+            } @else if (isExternalCertificate) {
+              <p class="hint">
+                This will import the external CA key and certificate, then create a rotating leaf
+                signing key.
               </p>
             } @else if (selectedUsage === 'attestation' && !isInternalChain) {
               <p class="hint">This will create a standalone self-signed key.</p>
@@ -269,6 +289,85 @@
                   <mat-hint> Selected provider stores and signs with this key chain. </mat-hint>
                 }
               </mat-form-field>
+
+              @if (!isInternalChain && selectedUsage !== 'access') {
+                <mat-checkbox formControlName="useExternalCertificate">
+                  Use an externally issued certificate and matching private key
+                </mat-checkbox>
+              }
+
+              @if (isExternalCertificate) {
+                <mat-form-field appearance="outline">
+                  <mat-label for="external-private-key">
+                    {{
+                      isExternalCaChain
+                        ? 'External CA Private Key (JWK)'
+                        : 'External Private Key (JWK)'
+                    }}
+                  </mat-label>
+                  <textarea
+                    matInput
+                    id="external-private-key"
+                    aria-label="External private key in JWK format"
+                    formControlName="externalPrivateKey"
+                    rows="6"
+                    placeholder="Paste the EC private JWK"
+                  ></textarea>
+                  <mat-hint>
+                    Must match the public key in the supplied
+                    {{ isExternalCaChain ? 'CA certificate.' : 'leaf certificate.' }}
+                  </mat-hint>
+                  <input
+                    #privateKeyFile
+                    type="file"
+                    accept=".json,.jwk,application/json"
+                    hidden
+                    (change)="onPrivateKeyFileSelected($event)"
+                  />
+                </mat-form-field>
+                <button mat-button type="button" (click)="privateKeyFile.click()">
+                  <mat-icon>upload_file</mat-icon>
+                  Load JWK File
+                </button>
+
+                <mat-form-field appearance="outline">
+                  <mat-label for="external-certificate-chain">
+                    {{
+                      isExternalCaChain
+                        ? 'External CA Certificate Chain (PEM)'
+                        : 'Certificate Chain (PEM)'
+                    }}
+                  </mat-label>
+                  <textarea
+                    matInput
+                    id="external-certificate-chain"
+                    aria-label="External certificate chain"
+                    formControlName="externalCertificate"
+                    rows="8"
+                    placeholder="-----BEGIN CERTIFICATE-----"
+                  ></textarea>
+                  <mat-hint>
+                    {{
+                      isExternalCaChain
+                        ? 'The last certificate must be the CA certificate matching the supplied key.'
+                        : 'Paste the leaf certificate first, followed by any issuing certificates.'
+                    }}
+                    Or load certificate files.
+                  </mat-hint>
+                  <input
+                    #certificateFiles
+                    type="file"
+                    accept=".pem,.crt,.cer,.der,application/x-pem-file,application/pkix-cert"
+                    multiple
+                    hidden
+                    (change)="onCertificateFilesSelected($event)"
+                  />
+                </mat-form-field>
+                <button mat-button type="button" (click)="certificateFiles.click()">
+                  <mat-icon>upload_file</mat-icon>
+                  Load Certificate Files
+                </button>
+              }
             </mat-card-content>
           </mat-card>
 
@@ -331,7 +430,15 @@
                 }
               </div>
 
-              @if (selectedUsage === 'attestation' && isInternalChain) {
+              @if (isExternalCaChain) {
+                <div class="next-steps-hint">
+                  <mat-icon>autorenew</mat-icon>
+                  <span>
+                    EUDIPLO will use the external CA to issue the active signing certificate and
+                    rotate that signing key according to the configured policy.
+                  </span>
+                </div>
+              } @else if (selectedUsage === 'attestation' && isInternalChain) {
                 <div class="next-steps-hint">
                   <mat-icon>info</mat-icon>
                   <span>
@@ -387,6 +494,8 @@
                 <mat-icon class="spinning">sync</mat-icon>
                 @if (selectedUsage === 'access' && selectedAccessSource === 'registrar') {
                   <ng-container>Enrolling...</ng-container>
+                } @else if (isExternalCertificate) {
+                  <ng-container>Importing...</ng-container>
                 } @else {
                   <ng-container>Creating...</ng-container>
                 }
@@ -396,12 +505,18 @@
                 mat-flat-button
                 type="button"
                 color="primary"
-                [disabled]="!configForm.valid"
+                [disabled]="!configForm.valid || !externalCertificateFormValid"
                 (click)="createKey()"
               >
                 <mat-icon>vpn_key</mat-icon>
                 @if (selectedUsage === 'access' && selectedAccessSource === 'registrar') {
                   <ng-container>Create & Enroll</ng-container>
+                } @else if (isExternalCertificate) {
+                  <ng-container>
+                    {{
+                      isExternalCaChain ? 'Import CA & Create Chain' : 'Import Key & Certificate'
+                    }}
+                  </ng-container>
                 } @else {
                   <ng-container>Create Key Chain</ng-container>
                 }

--- a/apps/client/src/app/key-management/key-create-wizard/key-create-wizard.component.ts
+++ b/apps/client/src/app/key-management/key-create-wizard/key-create-wizard.component.ts
@@ -621,7 +621,10 @@ export class KeyCreateWizardComponent implements OnInit {
     const bytes = new Uint8Array(content);
     let binary = '';
     for (const byte of bytes) binary += String.fromCodePoint(byte);
-    const base64 = btoa(binary).match(/.{1,64}/g)?.join('\n') || '';
+    const base64 =
+      btoa(binary)
+        .match(/.{1,64}/g)
+        ?.join('\n') || '';
     return `-----BEGIN CERTIFICATE-----\n${base64}\n-----END CERTIFICATE-----`;
   }
 }

--- a/apps/client/src/app/key-management/key-create-wizard/key-create-wizard.component.ts
+++ b/apps/client/src/app/key-management/key-create-wizard/key-create-wizard.component.ts
@@ -3,6 +3,7 @@ import { Component, OnInit, ViewChild, ChangeDetectionStrategy } from '@angular/
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
@@ -16,11 +17,11 @@ import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { FlexLayoutModule } from 'ngx-flexible-layout';
 import { KeyChainService } from '../key-chain.service';
 import { RegistrarConfig, RegistrarService } from '../../registrar/registrar.service';
-import { KeyChainCreateDto, KmsProviderInfoDto } from '@eudiplo/sdk-core';
+import { KeyChainCreateDto, KeyChainImportDto, KmsProviderInfoDto } from '@eudiplo/sdk-core';
 
 export type KeyUsageSelection = 'attestation' | 'statusList' | 'access' | 'trustList';
-export type KeyChainTypeSelection = 'internalChain' | 'standalone';
-export type AccessSourceSelection = 'selfSigned' | 'registrar';
+export type KeyChainTypeSelection = 'internalChain' | 'externalCaChain' | 'standalone';
+export type AccessSourceSelection = 'selfSigned' | 'registrar' | 'external';
 
 @Component({
   selector: 'app-key-create-wizard',
@@ -29,6 +30,7 @@ export type AccessSourceSelection = 'selfSigned' | 'registrar';
     CommonModule,
     MatButtonModule,
     MatCardModule,
+    MatCheckboxModule,
     MatFormFieldModule,
     MatIconModule,
     MatInputModule,
@@ -113,6 +115,14 @@ export class KeyCreateWizardComponent implements OnInit {
       hint: 'For simple setups or external PKI integration.',
       features: ['Self-signed certificate', 'Manual certificate management', 'Simple setup'],
     },
+    {
+      value: 'externalCaChain' as KeyChainTypeSelection,
+      label: 'External CA Chain',
+      icon: 'verified',
+      description: 'Use an external CA certificate to sign rotating leaf certificates.',
+      hint: 'EUDIPLO manages leaf-key rotation while your CA key remains the signing anchor.',
+      features: ['External CA certificate', 'Automatic leaf rotation', 'CA key remains managed'],
+    },
   ];
 
   // Access source options (shown for access keys)
@@ -130,6 +140,13 @@ export class KeyCreateWizardComponent implements OnInit {
       icon: 'verified',
       description: 'Obtain a certificate through your registrar.',
       hint: 'Required for production. Provides a trusted certificate chain.',
+    },
+    {
+      value: 'external' as AccessSourceSelection,
+      label: 'External Certificate',
+      icon: 'upload_file',
+      description: 'Use a certificate issued by an external CA or PKI.',
+      hint: 'Provide the matching private JWK and certificate chain below.',
     },
   ];
 
@@ -166,6 +183,9 @@ export class KeyCreateWizardComponent implements OnInit {
       rotationEnabled: [true],
       rotationIntervalDays: [30, [Validators.min(1)]],
       certValidityDays: [365, [Validators.min(1)]],
+      externalPrivateKey: [''],
+      externalCertificate: [''],
+      useExternalCertificate: [false],
     });
   }
 
@@ -262,12 +282,39 @@ export class KeyCreateWizardComponent implements OnInit {
   }
 
   get isInternalChain(): boolean {
-    return this.selectedUsage === 'attestation' && this.selectedKeyChainType === 'internalChain';
+    return (
+      this.selectedUsage === 'attestation' &&
+      (this.selectedKeyChainType === 'internalChain' ||
+        this.selectedKeyChainType === 'externalCaChain')
+    );
+  }
+
+  get isExternalCaChain(): boolean {
+    return this.selectedUsage === 'attestation' && this.selectedKeyChainType === 'externalCaChain';
   }
 
   get rotationEnabled(): boolean {
     // Rotation can be enabled for internal chain keys
     return this.isInternalChain && this.configForm.value.rotationEnabled;
+  }
+
+  get isExternalCertificate(): boolean {
+    return (
+      (this.selectedUsage === 'access' && this.selectedAccessSource === 'external') ||
+      this.isExternalCaChain ||
+      (!!this.selectedUsage &&
+        this.selectedUsage !== 'access' &&
+        !this.isInternalChain &&
+        this.configForm.value.useExternalCertificate)
+    );
+  }
+
+  get externalCertificateFormValid(): boolean {
+    return (
+      !this.isExternalCertificate ||
+      (!!this.configForm.value.externalPrivateKey?.trim() &&
+        !!this.configForm.value.externalCertificate?.trim())
+    );
   }
 
   /**
@@ -321,6 +368,33 @@ export class KeyCreateWizardComponent implements OnInit {
       const usage = this.selectedUsage!;
       const description = this.configForm.value.description?.trim();
       const isRegistrarEnrollment = usage === 'access' && this.selectedAccessSource === 'registrar';
+
+      if (this.isExternalCertificate) {
+        const externalKey = this.parseExternalPrivateKey();
+        const externalCertificates = this.parseCertificateChain(
+          this.configForm.value.externalCertificate
+        );
+        const importDto: KeyChainImportDto = {
+          key: externalKey,
+          usageType: usage,
+          description: description || this.getDefaultDescription(),
+          kmsProvider: this.configForm.value.kmsProvider || this.defaultKmsProvider || 'db',
+          crt: externalCertificates,
+          rotationPolicy: this.isExternalCaChain
+            ? {
+                enabled: true,
+                intervalDays: this.configForm.value.rotationIntervalDays,
+                certValidityDays: this.configForm.value.certValidityDays,
+              }
+            : undefined,
+        };
+        const result = await this.keyChainService.import(importDto);
+        this.snackBar.open('External certificate imported successfully!', 'View Key', {
+          duration: 5000,
+        });
+        this.router.navigate(['/keys', result.id]);
+        return;
+      }
 
       // Build the KeyChainCreateDto
       const createDto: KeyChainCreateDto = {
@@ -446,9 +520,7 @@ export class KeyCreateWizardComponent implements OnInit {
     }
 
     if (this.selectedUsage === 'access') {
-      const certSource =
-        this.selectedAccessSource === 'registrar' ? 'Registrar Enrollment' : 'Self-Signed';
-      summary.push({ label: 'Certificate', value: certSource });
+      summary.push({ label: 'Certificate', value: this.getCertificateSourceLabel() });
     }
 
     if (this.configForm.value.description) {
@@ -465,7 +537,12 @@ export class KeyCreateWizardComponent implements OnInit {
     }
 
     if (this.isInternalChain) {
-      summary.push({ label: 'Type', value: 'Internal Chain (Root CA + Signing Key)' });
+      summary.push({
+        label: 'Type',
+        value: this.isExternalCaChain
+          ? 'External CA Chain (Rotating Signing Key)'
+          : 'Internal Chain (Root CA + Signing Key)',
+      });
       if (this.rotationEnabled) {
         summary.push({
           label: 'Rotation Interval',
@@ -477,9 +554,74 @@ export class KeyCreateWizardComponent implements OnInit {
         value: `${this.configForm.value.certValidityDays} days`,
       });
     } else {
-      summary.push({ label: 'Type', value: 'Standalone (Self-signed)' });
+      summary.push({
+        label: 'Type',
+        value: this.getKeyTypeLabel(),
+      });
     }
 
     return summary;
+  }
+
+  private getCertificateSourceLabel(): string {
+    if (this.selectedAccessSource === 'registrar') return 'Registrar Enrollment';
+    if (this.selectedAccessSource === 'external') return 'External Certificate';
+    return 'Self-Signed';
+  }
+
+  private getKeyTypeLabel(): string {
+    return this.isExternalCertificate
+      ? 'Standalone (External Certificate)'
+      : 'Standalone (Self-signed)';
+  }
+
+  private parseExternalPrivateKey(): KeyChainImportDto['key'] {
+    try {
+      const key = JSON.parse(this.configForm.value.externalPrivateKey);
+      if (!key || typeof key !== 'object' || !key.kty || !key.x || !key.y || !key.crv || !key.d) {
+        throw new Error('Invalid private JWK');
+      }
+      return key as KeyChainImportDto['key'];
+    } catch {
+      throw new Error('The external private key must be a valid EC private JWK.');
+    }
+  }
+
+  private parseCertificateChain(value: string): string[] {
+    const certificates = value
+      .trim()
+      .split(/(?=-----BEGIN CERTIFICATE-----)/g)
+      .map((certificate) => certificate.trim())
+      .filter(Boolean);
+    if (certificates.length === 0) {
+      throw new Error('At least one certificate is required.');
+    }
+    return certificates;
+  }
+
+  async onPrivateKeyFileSelected(event: Event): Promise<void> {
+    const file = (event.target as HTMLInputElement).files?.[0];
+    if (!file) return;
+    this.configForm.patchValue({ externalPrivateKey: await file.text() });
+  }
+
+  async onCertificateFilesSelected(event: Event): Promise<void> {
+    const files = Array.from((event.target as HTMLInputElement).files || []);
+    if (files.length === 0) return;
+
+    const certificates = await Promise.all(files.map((file) => this.readCertificateFile(file)));
+    this.configForm.patchValue({ externalCertificate: certificates.join('\n') });
+  }
+
+  private async readCertificateFile(file: File): Promise<string> {
+    const content = await file.arrayBuffer();
+    const text = new TextDecoder().decode(content).trim();
+    if (text.includes('-----BEGIN CERTIFICATE-----')) return text;
+
+    const bytes = new Uint8Array(content);
+    let binary = '';
+    for (const byte of bytes) binary += String.fromCodePoint(byte);
+    const base64 = btoa(binary).match(/.{1,64}/g)?.join('\n') || '';
+    return `-----BEGIN CERTIFICATE-----\n${base64}\n-----END CERTIFICATE-----`;
   }
 }

--- a/apps/docs/docs/trust/certificates.md
+++ b/apps/docs/docs/trust/certificates.md
@@ -39,6 +39,17 @@ Bring existing certificates from external PKI systems. Useful when:
 
 Imported certificates must include both the certificate and private key material (for database-backed keys) or reference existing keys (for Vault/AWS KMS).
 
+When importing a certificate chain, provide the leaf certificate first and any issuing
+certificates after it. For an external CA-backed rotating internal chain, provide the CA
+certificate last. The CA certificate must have `CA=true` and match the supplied private key.
+
+The web key-creation wizard supports pasted PEM values and PEM, CRT, CER, or DER certificate
+files. It validates the key/certificate relationship before the key chain is created.
+
+For an attestation internal chain backed by an external CA, EUDIPLO uses the imported CA key to
+sign newly generated active leaf keys. Leaf keys and certificates rotate according to the key
+chain's rotation policy; the external CA key remains the signing anchor.
+
 ## Access Certificates vs Attestation Certificates
 
 EUDIPLO uses certificates for different purposes:

--- a/apps/docs/docs/trust/key-chains.md
+++ b/apps/docs/docs/trust/key-chains.md
@@ -15,21 +15,25 @@ A key chain encapsulates:
 - **Previous key** (for grace period after rotation)
 - **Rotation policy** (automatic certificate renewal)
 
-```
-┌─────────────────────────────────────────────┐
-│               Key Chain                      │
-├─────────────────────────────────────────────┤
-│  Root CA Key (optional)                      │
-│  Root CA Certificate (self-signed)           │
-├─────────────────────────────────────────────┤
-│  Active Signing Key                          │
-│  Active Certificate (CA-signed or self)      │
-├─────────────────────────────────────────────┤
-│  Previous Key (optional, grace period)       │
-│  Previous Certificate                        │
-├─────────────────────────────────────────────┤
-│  Rotation Policy                             │
-└─────────────────────────────────────────────┘
+```mermaid
+flowchart TB
+  KC[Key Chain]
+
+  KC --> ROOT[Root CA]
+  ROOT --> ROOTKEY[CA Private Key]
+  ROOT --> ROOTCERT[CA Certificate]
+
+  KC --> ACTIVE[Active Signing Key]
+  ACTIVE --> ACTIVECERT[Leaf Certificate]
+
+  KC --> PREVIOUS[Previous Key]
+  PREVIOUS --> PREVCERT[Previous Certificate]
+
+  KC --> POLICY[Rotation Policy]
+
+  ROOTCERT -->|signs| ACTIVECERT
+  POLICY -->|rotates| ACTIVE
+  ACTIVE -. grace period .-> PREVIOUS
 ```
 
 Each tenant can manage multiple key chains simultaneously. Each key chain has a unique ID and is isolated via the `tenant_id` field.
@@ -38,13 +42,13 @@ Each tenant can manage multiple key chains simultaneously. Each key chain has a 
 
 Key chains are organized by usage type:
 
-| Usage          | Purpose                                  |
-| -------------- | ---------------------------------------- |
-| `access`       | Access certificates for wallet requests  |
-| `attestation`  | Credential signing keys                  |
-| `trustList`    | Trust list signing keys                  |
-| `statusList`   | Status list signing keys                 |
-| `encrypt`      | Encryption keys for response encryption  |
+| Usage         | Purpose                                 |
+| ------------- | --------------------------------------- |
+| `access`      | Access certificates for wallet requests |
+| `attestation` | Credential signing keys                 |
+| `trustList`   | Trust list signing keys                 |
+| `statusList`  | Status list signing keys                |
+| `encrypt`     | Encryption keys for response encryption |
 
 ## Creating a Key Chain
 
@@ -53,8 +57,19 @@ Key chains are organized by usage type:
 1. Navigate to **Keys** in the sidebar
 2. Click **+ Create Key** to open the wizard
 3. Select the usage type
-4. Enter a name for the key chain
-5. Click **Create**
+4. Select how the key and certificate should be provisioned
+5. Enter a description and select the KMS provider
+6. Click **Create**
+
+For standalone keys, choose the external certificate option to provide an existing private EC
+JWK and certificate chain. The certificate's public key must match the private JWK. The wizard
+accepts pasted PEM values and PEM, CRT, CER, or DER certificate files.
+
+For an attestation key using an **External CA Chain**, provide the external CA private JWK and
+certificate chain. EUDIPLO imports the CA key, generates the active signing key, has the CA sign
+that key, and rotates the active signing key according to the configured policy. The last
+certificate in the supplied chain must be the CA certificate matching the private JWK and must
+have `CA=true`.
 
 ### Via the API
 
@@ -91,6 +106,42 @@ Key chains support automatic rotation based on certificate expiry. When a certif
 
 This ensures uninterrupted service during key transitions.
 
+### External CA Rotation
+
+An internal chain can use an external CA as its signing anchor. In this mode:
+
+- The imported private key and final certificate in `crt` represent the CA
+- EUDIPLO generates the active leaf signing key
+- The external CA signs the generated leaf certificate
+- EUDIPLO rotates the leaf key and certificate; the CA key remains the root signing anchor
+
+This mode is available through the web wizard for attestation key chains and through the key-chain
+import API with `rotationPolicy.enabled=true`.
+
+Example import payload:
+
+```json
+{
+    "usageType": "attestation",
+    "key": {
+        "kty": "EC",
+        "crv": "P-256",
+        "x": "<ca-public-x>",
+        "y": "<ca-public-y>",
+        "d": "<ca-private-d>",
+        "alg": "ES256"
+    },
+    "crt": ["<optional-intermediate-certificate-pem>", "<ca-certificate-pem>"],
+    "rotationPolicy": {
+        "enabled": true,
+        "intervalDays": 30,
+        "certValidityDays": 365
+    }
+}
+```
+
+The imported CA certificate is validated for `CA=true` and must match the supplied private key.
+
 ## Where Keys Are Stored
 
 EUDIPLO supports pluggable KMS backends:
@@ -114,6 +165,15 @@ Key chains can contain different certificate types depending on how they're prov
 - **Registrar-obtained** — Access certificates from EUDI Wallet registrar
 
 See [Certificates](certificates.md) for details on certificate management.
+
+## External Certificate Import
+
+External certificate import is supported for standalone access, attestation, status-list, and
+trust-list key chains. The imported certificate chain is stored as the active certificate, and
+the first certificate is validated against the supplied private key.
+
+For internal attestation chains, use **External CA Chain** instead. This imports an external CA
+signing anchor while retaining EUDIPLO's rotating leaf-key lifecycle.
 
 ## Best Practices
 


### PR DESCRIPTION
## 📝 Description

Adds external certificate support to key-chain generation and documents the supported provisioning modes.

The key wizard now supports:
- Importing external key/certificate material for standalone access, attestation, status-list, and trust-list key chains.
- Using an external CA private key and CA certificate as the signing anchor for rotating attestation chains.
- Loading private JWK files and PEM, CRT, CER, or DER certificate files.

The backend validates that imported certificates match their supplied keys and validates external CA certificates for rotation.

## 🔄 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test improvements
- [ ] 🏗️ Build/CI changes

## 💥 Breaking Changes (if applicable)

No breaking changes. Existing create, registrar, generated internal-chain, and standalone flows remain unchanged.

## 🧪 Testing

- [x] Unit tests pass
- [x] Integration tests pass
- [x] E2E tests pass
- [ ] Manual testing performed

**Test Configuration**:

- Node.js version: repository-configured environment
- OS: macOS
- Test environment: local workspace

Validation run:
- `pnpm --filter @eudiplo/client build`
- `pnpm --filter @eudiplo/backend build`
- `pnpm --filter @eudiplo/docs lint`
- `pnpm --filter @eudiplo/docs build`
- `pnpm --filter @eudiplo/backend test:e2e -- key-import.e2e-spec.ts`
- Workspace formatting, lint, and Knip hooks

## 📸 Screenshots (if applicable)

Not applicable.

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have corresponding documentation changes
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 📋 Additional Notes

External CA rotation uses the existing import rotation contract: the imported key and final certificate in the supplied chain are treated as the CA, while EUDIPLO generates and rotates the active leaf signing key.
