### PR TITLE
feat(client): improve light and dark theme support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,6 +58,7 @@
   - Smart components: orchestrate data and logic
   - Dumb components: only receive `@Input` / emit `@Output` (UI only)
 - Store shared state in services with `BehaviorSubject` for state and `Observable` for consumption.
+- Use Angular Material theme tokens or shared semantic CSS variables for UI colors instead of hard-coded color values, and define light/dark variants so both themes remain readable. Literal colors are appropriate for user-configured or data-driven branding values.
 
 ## Protocol Flow Rules (OID4VCI / OID4VP)
 - **Credential Issuance**: Always validate Access Tokens and DPoP (if enabled) before issuing. Never hardcode client metadata; use resolved metadata from configuration.

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -57,6 +57,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",
     "istanbul-lib-instrument": "^6.0.3",
+    "jsdom": "^30.0.1",
     "karma": "~6.4.4",
     "playwright-ng-schematics": "22.0.3",
     "prettier": "^3.9.6",

--- a/apps/client/src/app/admin/admin-activity-logs/admin-activity-logs.component.scss
+++ b/apps/client/src/app/admin/admin-activity-logs/admin-activity-logs.component.scss
@@ -59,10 +59,10 @@
   align-items: flex-start;
   gap: 12px;
   padding: 16px;
-  background-color: #ffebee;
-  border-left: 4px solid #f44336;
+  background-color: var(--mat-sys-error-container);
+  border-left: 4px solid var(--eudiplo-danger);
   border-radius: 4px;
-  color: #c62828;
+  color: var(--eudiplo-danger);
 
   mat-icon {
     flex-shrink: 0;
@@ -81,7 +81,7 @@
   justify-content: center;
   padding: 40px;
   text-align: center;
-  color: var(--text-secondary, #999);
+  color: var(--text-secondary, var(--mat-sys-on-surface-variant));
 
   mat-icon {
     font-size: 48px;
@@ -106,7 +106,7 @@
   display: flex;
   align-items: center;
   justify-content: stretch;
-  border-top: 1px solid var(--divider-color, #e0e0e0);
+  border-top: 1px solid var(--divider-color, var(--mat-sys-outline-variant));
   width: 100%;
 
   mat-paginator {
@@ -127,17 +127,17 @@
   text-transform: uppercase;
 
   &.action-tenant_created {
-    background-color: #c8e6c9;
-    color: #2e7d32;
+    background-color: var(--mat-sys-secondary-container);
+    color: var(--eudiplo-success);
   }
 
   &.action-tenant_updated {
-    background-color: #bbdefb;
-    color: #1565c0;
+    background-color: var(--mat-sys-primary-container);
+    color: var(--eudiplo-info);
   }
 
   &.action-tenant_deleted {
-    background-color: #ffccbc;
-    color: #d84315;
+    background-color: var(--mat-sys-tertiary-container);
+    color: var(--eudiplo-warning);
   }
 }

--- a/apps/client/src/app/app.component.html
+++ b/apps/client/src/app/app.component.html
@@ -9,6 +9,24 @@
     <!-- Spacer -->
     <span fxFlex></span>
 
+    <a
+      matIconButton
+      href="https://docs.eudiplo.dev/"
+      target="_blank"
+      rel="noopener"
+      aria-label="Open documentation"
+      matTooltip="Documentation"
+    >
+      <mat-icon>help</mat-icon>
+    </a>
+    <button
+      matIconButton
+      (click)="themeService.toggle()"
+      [attr.aria-label]="themeService.isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'"
+      [matTooltip]="themeService.isDarkMode ? 'Light mode' : 'Dark mode'"
+    >
+      <mat-icon>{{ themeService.isDarkMode ? 'light_mode' : 'dark_mode' }}</mat-icon>
+    </button>
     <button matIconButton [matMenuTriggerFor]="menu" aria-label="Example icon-button with a menu">
       <mat-icon>more_vert</mat-icon>
     </button>
@@ -21,10 +39,6 @@
         <mat-icon>business</mat-icon>
         <span>Instance: {{ apiService.getBaseUrl() }}</span>
       </button>
-      <a mat-menu-item href="https://docs.eudiplo.dev/" target="_blank" rel="noopener">
-        <mat-icon>help</mat-icon>
-        Documentation
-      </a>
 
       <button mat-menu-item (click)="logout()" matTooltip="Logout">
         <mat-icon>logout</mat-icon>

--- a/apps/client/src/app/app.component.scss
+++ b/apps/client/src/app/app.component.scss
@@ -47,7 +47,13 @@
   padding: 20px;
   overflow-y: auto; // Allow scrolling if content overflows
   height: calc(100vh - 104px); // Account for toolbar height
-  background-color: #f6f6f6;
+  background-color: var(--mat-sys-background);
+}
+
+:host-context(html.dark-theme) {
+  .warning-icon {
+    color: var(--eudiplo-warning);
+  }
 }
 
 .active-link {
@@ -75,7 +81,7 @@
 }
 
 .warning-icon {
-  color: #ff9800;
+  color: var(--eudiplo-warning);
 }
 
 // Mobile specific adjustments

--- a/apps/client/src/app/app.component.ts
+++ b/apps/client/src/app/app.component.ts
@@ -15,6 +15,7 @@ import { FlexLayoutModule } from 'ngx-flexible-layout';
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { JwtService, Role } from './services/jwt.service';
+import { ThemeService } from './services/theme.service';
 import { ApiService } from './core';
 
 @Component({
@@ -53,7 +54,8 @@ export class AppComponent implements OnInit, OnDestroy {
     private router: Router,
     public apiService: ApiService,
     private breakpointObserver: BreakpointObserver,
-    public jwtService: JwtService
+    public jwtService: JwtService,
+    public themeService: ThemeService
   ) {}
 
   ngOnInit(): void {

--- a/apps/client/src/app/config-portability/config-portability.component.scss
+++ b/apps/client/src/app/config-portability/config-portability.component.scss
@@ -82,7 +82,7 @@ table {
   margin: 6px 0;
 
   &.warning {
-    color: #8a5a00;
+    color: var(--eudiplo-warning);
   }
 
   code {

--- a/apps/client/src/app/dashboard/dashboard.component.scss
+++ b/apps/client/src/app/dashboard/dashboard.component.scss
@@ -38,12 +38,12 @@ mat-icon[mat-card-avatar] {
     margin: 0;
     font-size: 28px;
     font-weight: 500;
-    color: #1976d2;
+    color: var(--mat-sys-primary);
   }
 
   .subtitle {
     margin: 4px 0 0;
-    color: #666;
+    color: var(--mat-sys-on-surface-variant);
     font-size: 14px;
   }
 }
@@ -51,26 +51,26 @@ mat-icon[mat-card-avatar] {
 // Setup Card
 .setup-card {
   width: 100%;
-  border-left: 4px solid #e65100;
-  background: linear-gradient(135deg, #fffbf0 0%, #ffffff 100%);
+  border-left: 4px solid var(--eudiplo-warning);
+  background: var(--mat-sys-surface-container);
 
   .setup-icon {
-    color: #bf360c;
-    background: #ffccbc;
+    color: var(--mat-sys-on-tertiary-container);
+    background: var(--mat-sys-tertiary-container);
   }
 
   &.readonly-card {
-    border-left-color: #1565c0;
-    background: linear-gradient(135deg, #eef7ff 0%, #ffffff 100%);
+    border-left-color: var(--eudiplo-info);
+    background: var(--mat-sys-surface-container);
 
     .setup-icon {
-      color: #0d47a1;
-      background: #bbdefb;
+      color: var(--mat-sys-on-primary-container);
+      background: var(--mat-sys-primary-container);
     }
   }
 
   &.warnings-card {
-    border-left-color: #e65100;
+    border-left-color: var(--eudiplo-warning);
   }
 
   .setup-section {
@@ -83,10 +83,10 @@ mat-icon[mat-card-avatar] {
       margin: 0 0 4px;
       font-size: 16px;
       font-weight: 500;
-      color: #333;
+      color: var(--mat-sys-on-surface);
 
       mat-icon {
-        color: #e65100;
+        color: var(--eudiplo-warning);
         font-size: 20px;
         width: 20px;
         height: 20px;
@@ -96,7 +96,7 @@ mat-icon[mat-card-avatar] {
     .section-description {
       margin: 0 0 12px;
       font-size: 13px;
-      color: #666;
+      color: var(--mat-sys-on-surface-variant);
       padding-left: 28px;
     }
   }
@@ -109,13 +109,13 @@ mat-icon[mat-card-avatar] {
     .setup-track {
       padding: 16px;
       border-radius: 8px;
-      background: rgba(255, 255, 255, 0.5);
-      border: 1px dashed #e0e0e0;
+      background: var(--mat-sys-surface-container-high);
+      border: 1px dashed var(--mat-sys-outline-variant);
       transition: all 0.2s ease;
 
       &.ready {
-        background: rgba(76, 175, 80, 0.05);
-        border: 1px solid rgba(76, 175, 80, 0.3);
+        background: var(--eudiplo-success-subtle);
+        border: 1px solid var(--eudiplo-success-border);
       }
 
       .track-title {
@@ -125,7 +125,7 @@ mat-icon[mat-card-avatar] {
         margin: 0 0 12px;
         font-size: 15px;
         font-weight: 500;
-        color: #333;
+        color: var(--mat-sys-on-surface);
 
         mat-icon {
           font-size: 20px;
@@ -138,8 +138,8 @@ mat-icon[mat-card-avatar] {
           min-height: 22px;
 
           &.reason-chip {
-            background: rgba(230, 81, 0, 0.12);
-            color: #8e3a00;
+            background: var(--eudiplo-warning-soft);
+            color: var(--eudiplo-warning);
           }
         }
       }
@@ -154,15 +154,15 @@ mat-icon[mat-card-avatar] {
     .setup-step {
       padding: 12px;
       border-radius: 8px;
-      background: rgba(255, 255, 255, 0.7);
+      background: var(--mat-sys-surface-container-high);
       transition: all 0.2s ease;
 
       &:hover {
-        background: rgba(255, 255, 255, 0.9);
+        background: var(--mat-sys-surface-container-highest);
       }
 
       &.completed {
-        background: rgba(76, 175, 80, 0.1);
+        background: var(--eudiplo-success-soft);
       }
 
       &.disabled {
@@ -171,20 +171,20 @@ mat-icon[mat-card-avatar] {
       }
 
       mat-icon {
-        color: #bdbdbd;
+        color: var(--mat-sys-on-surface-variant);
         font-size: 24px;
         width: 24px;
         height: 24px;
 
         &.done {
-          color: #4caf50;
+          color: var(--eudiplo-success);
         }
       }
 
       p {
         margin: 4px 0 0;
         font-size: 12px;
-        color: #666;
+        color: var(--mat-sys-on-surface-variant);
       }
 
       mat-chip {
@@ -231,7 +231,7 @@ mat-icon[mat-card-avatar] {
   &:hover {
     transform: translateY(-4px);
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
-    border-color: #1976d2;
+    border-color: var(--eudiplo-info);
   }
 
   mat-card-content {
@@ -246,32 +246,32 @@ mat-icon[mat-card-avatar] {
     margin-bottom: 12px;
 
     &.credential {
-      color: #1976d2;
+      color: var(--eudiplo-info);
     }
 
     &.presentation {
-      color: #7b1fa2;
+      color: var(--eudiplo-accent);
     }
 
     &.keys {
-      color: #f57c00;
+      color: var(--eudiplo-warning);
     }
 
     &.sessions {
-      color: #388e3c;
+      color: var(--eudiplo-success);
     }
   }
 
   .stat-value {
     font-size: 32px;
     font-weight: 600;
-    color: #333;
+    color: var(--mat-sys-on-surface);
     line-height: 1;
   }
 
   .stat-label {
     font-size: 12px;
-    color: #666;
+    color: var(--mat-sys-on-surface-variant);
     margin-top: 8px;
     text-transform: uppercase;
     letter-spacing: 0.5px;
@@ -283,8 +283,8 @@ mat-icon[mat-card-avatar] {
   width: 100%;
 
   mat-icon[mat-card-avatar] {
-    background: #e3f2fd;
-    color: #0d47a1;
+    background: var(--mat-sys-primary-container);
+    color: var(--mat-sys-on-primary-container);
   }
 
   .session-stats {
@@ -292,7 +292,7 @@ mat-icon[mat-card-avatar] {
 
     .session-stat {
       padding: 8px 16px;
-      background: #f5f5f5;
+      background: var(--mat-sys-surface-container-high);
       border-radius: 20px;
 
       mat-icon {
@@ -302,23 +302,23 @@ mat-icon[mat-card-avatar] {
       }
 
       .status-active {
-        color: #0d47a1;
+        color: var(--mat-sys-primary);
       }
 
       .status-fetched {
-        color: #5d4037;
+        color: var(--mat-sys-tertiary);
       }
 
       .status-completed {
-        color: #2e7d32;
+        color: var(--eudiplo-success);
       }
 
       .status-expired {
-        color: #e65100;
+        color: var(--eudiplo-warning);
       }
 
       .status-failed {
-        color: #c62828;
+        color: var(--eudiplo-danger);
       }
     }
   }
@@ -329,8 +329,8 @@ mat-icon[mat-card-avatar] {
   width: 100%;
 
   mat-icon[mat-card-avatar] {
-    background: #ffccbc;
-    color: #bf360c;
+    background: var(--mat-sys-tertiary-container);
+    color: var(--mat-sys-on-tertiary-container);
   }
 
   .quick-actions {
@@ -354,24 +354,24 @@ mat-icon[mat-card-avatar] {
     gap: 8px;
     margin-top: 16px;
     padding: 12px 16px;
-    background-color: #e3f2fd;
+    background-color: var(--mat-sys-primary-container);
     border-radius: 8px;
-    color: #1565c0;
+    color: var(--mat-sys-on-primary-container);
     font-size: 14px;
 
     mat-icon {
-      color: #1976d2;
+      color: var(--mat-sys-primary);
       flex-shrink: 0;
     }
 
     a {
-      color: #1565c0;
+      color: var(--mat-sys-primary);
       font-weight: 500;
       text-decoration: underline;
       cursor: pointer;
 
       &:hover {
-        color: #0d47a1;
+        color: var(--mat-sys-primary);
       }
     }
   }
@@ -382,8 +382,8 @@ mat-icon[mat-card-avatar] {
   width: 100%;
 
   mat-icon[mat-card-avatar] {
-    background: #e8f5e9;
-    color: #2e7d32;
+    background: var(--mat-sys-secondary-container);
+    color: var(--mat-sys-on-secondary-container);
   }
 
   .resource-links {
@@ -407,7 +407,7 @@ mat-icon[mat-card-avatar] {
     gap: 8px;
 
     mat-icon {
-      color: #666;
+      color: var(--mat-sys-on-surface-variant);
     }
   }
 

--- a/apps/client/src/app/issuance/attribute-provider/attribute-provider-create/attribute-provider-create.component.scss
+++ b/apps/client/src/app/issuance/attribute-provider/attribute-provider-create/attribute-provider-create.component.scss
@@ -9,7 +9,7 @@ mat-card-header {
     gap: 8px;
 
     mat-icon {
-      color: #666;
+      color: var(--mat-sys-on-surface-variant);
     }
   }
 }

--- a/apps/client/src/app/issuance/attribute-provider/attribute-provider-show/attribute-provider-show.component.scss
+++ b/apps/client/src/app/issuance/attribute-provider/attribute-provider-show/attribute-provider-show.component.scss
@@ -19,7 +19,7 @@ mat-card-header {
     gap: 8px;
 
     mat-icon {
-      color: #666;
+      color: var(--mat-sys-on-surface-variant);
     }
   }
 }

--- a/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.scss
+++ b/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.scss
@@ -23,8 +23,8 @@
   margin-left: 8px;
   padding: 0 5px;
   border-radius: 999px;
-  background-color: #d32f2f;
-  color: #fff;
+  background-color: var(--eudiplo-danger);
+  color: var(--mat-sys-on-error);
   font-size: 11px;
   font-weight: 600;
   line-height: 1;
@@ -38,19 +38,19 @@
 
 .option-description {
   font-size: 12px;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--mat-sys-on-surface-variant);
   margin-top: 2px;
 }
 
 .toggle-description {
   font-size: 12px;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--mat-sys-on-surface-variant);
   margin-top: 2px;
 }
 
 .menu-description {
   font-size: 11px;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--mat-sys-on-surface-variant);
   margin-top: 2px;
   white-space: normal;
   line-height: 1.2;
@@ -58,7 +58,7 @@
 
 .field-description {
   font-size: 13px;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--mat-sys-on-surface-variant);
   margin: 0 0 8px 0;
 }
 
@@ -67,7 +67,7 @@
   height: 32px;
   min-width: 32px;
   border-radius: 4px;
-  border: 1px solid rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--mat-sys-outline-variant);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.5);
 }
 
@@ -82,7 +82,7 @@ mat-accordion {
 
     mat-panel-description {
       font-size: 12px;
-      color: rgba(0, 0, 0, 0.6);
+      color: var(--mat-sys-on-surface-variant);
     }
   }
 }
@@ -101,7 +101,7 @@ mat-accordion {
 
 .display-config-card {
   margin: 16px 0;
-  border-left: 4px solid #1976d2;
+  border-left: 4px solid var(--eudiplo-info);
 
   mat-card-header {
     mat-card-title {
@@ -132,7 +132,7 @@ mat-accordion {
 
 .fields-empty-state {
   padding: 40px;
-  color: #888;
+  color: var(--mat-sys-on-surface-variant);
 
   mat-icon {
     font-size: 48px;
@@ -160,7 +160,7 @@ mat-card {
 
     mat-card-subtitle {
       margin-top: 8px;
-      color: rgba(0, 0, 0, 0.6);
+      color: var(--mat-sys-on-surface-variant);
     }
   }
 }
@@ -190,25 +190,25 @@ mat-slide-toggle {
 
 // Form validation styles
 .mat-mdc-form-field.mat-form-field-invalid .mat-mdc-text-field-wrapper {
-  border-color: #f44336;
+  border-color: var(--eudiplo-danger);
 }
 
 // Readonly input styles
 input[readonly] {
-  color: rgba(0, 0, 0, 0.6);
-  background-color: rgba(0, 0, 0, 0.04);
+  color: var(--mat-sys-on-surface-variant);
+  background-color: var(--mat-sys-surface-container-high);
 }
 
 // Action buttons container
 div[fxLayoutAlign='end center'] {
   margin-top: 32px;
   padding-top: 16px;
-  border-top: 1px solid rgba(0, 0, 0, 0.12);
+  border-top: 1px solid var(--mat-sys-outline-variant);
 }
 
 .form-errors-hint {
   margin-right: auto;
-  color: #d32f2f;
+  color: var(--eudiplo-danger);
   font-size: 13px;
 }
 
@@ -222,13 +222,13 @@ img {
   align-items: center;
   gap: 8px;
   padding: 12px 16px;
-  background-color: rgba(0, 0, 0, 0.04);
+  background-color: var(--mat-sys-surface-container-high);
   border-radius: 4px;
-  color: rgba(0, 0, 0, 0.7);
+  color: var(--mat-sys-on-surface-variant);
   font-size: 13px;
 
   mat-icon {
-    color: rgba(0, 0, 0, 0.54);
+    color: var(--mat-sys-on-surface-variant);
     font-size: 20px;
     width: 20px;
     height: 20px;
@@ -238,7 +238,7 @@ img {
   code {
     font-family: 'Roboto Mono', monospace;
     font-size: 12px;
-    background-color: rgba(0, 0, 0, 0.06);
+    background-color: var(--mat-sys-surface-container-high);
     padding: 2px 6px;
     border-radius: 3px;
   }
@@ -250,14 +250,14 @@ img {
   align-items: flex-start;
   gap: 8px;
   padding: 12px 16px;
-  background-color: rgba(25, 118, 210, 0.08);
+  background-color: var(--eudiplo-info-soft);
   border-radius: 4px;
-  color: rgba(0, 0, 0, 0.7);
+  color: var(--mat-sys-on-surface-variant);
   font-size: 13px;
   line-height: 1.5;
 
   mat-icon {
-    color: #1976d2;
+    color: var(--eudiplo-info);
     font-size: 20px;
     width: 20px;
     height: 20px;
@@ -268,7 +268,7 @@ img {
   code {
     font-family: 'Roboto Mono', monospace;
     font-size: 12px;
-    background-color: rgba(0, 0, 0, 0.06);
+    background-color: var(--mat-sys-surface-container-high);
     padding: 1px 4px;
     border-radius: 3px;
   }
@@ -278,14 +278,14 @@ img {
 .key-attestation-section {
   margin-top: 16px;
   padding: 16px;
-  border: 1px solid rgba(0, 0, 0, 0.12);
+  border: 1px solid var(--mat-sys-outline-variant);
   border-radius: 8px;
-  background-color: rgba(0, 0, 0, 0.02);
+  background-color: var(--mat-sys-surface-container-low);
 
   .key-attestation-fields {
     margin-top: 16px;
     padding-top: 16px;
-    border-top: 1px dashed rgba(0, 0, 0, 0.12);
+    border-top: 1px dashed var(--mat-sys-outline-variant);
   }
 }
 
@@ -294,11 +294,11 @@ img {
   .section-header {
     margin-bottom: 16px;
     padding-bottom: 8px;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+    border-bottom: 1px solid var(--mat-sys-outline-variant);
   }
 
   .no-actions-hint {
-    color: rgba(0, 0, 0, 0.6);
+    color: var(--mat-sys-on-surface-variant);
     font-style: italic;
     text-align: center;
     padding: 16px;
@@ -308,7 +308,7 @@ img {
 
 .iae-action-card {
   margin-bottom: 16px;
-  border-left: 4px solid #7b1fa2;
+  border-left: 4px solid var(--eudiplo-accent);
 
   &:hover {
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
@@ -330,7 +330,7 @@ img {
 
   .drag-handle {
     cursor: grab;
-    color: rgba(0, 0, 0, 0.4);
+    color: var(--mat-sys-on-surface-variant);
 
     &:active {
       cursor: grabbing;

--- a/apps/client/src/app/issuance/credential-config/credential-config-show/credential-config-show.component.scss
+++ b/apps/client/src/app/issuance/credential-config/credential-config-show/credential-config-show.component.scss
@@ -7,32 +7,32 @@
 }
 
 .value-text {
-  color: #666;
+  color: var(--mat-sys-on-surface-variant);
   margin-top: 4px;
   font-family: 'Roboto Mono', monospace;
   font-size: 14px;
 }
 
 .config-item {
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--mat-sys-outline-variant);
   border-radius: 4px;
   padding: 12px;
-  background-color: #fafafa;
+  background-color: var(--mat-sys-surface-container);
 
   .config-key {
     font-weight: 500;
-    color: #333;
+    color: var(--mat-sys-on-surface);
     margin-bottom: 8px;
   }
 
   .config-value {
-    background-color: #f5f5f5;
-    border: 1px solid #ddd;
+    background-color: var(--mat-sys-surface-container-high);
+    border: 1px solid var(--mat-sys-outline-variant);
     border-radius: 4px;
     padding: 8px;
     margin: 0;
     font-size: 12px;
-    color: #555;
+    color: var(--mat-sys-on-surface-variant);
     overflow-x: auto;
   }
 }
@@ -41,12 +41,12 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  color: #999;
+  color: var(--mat-sys-on-surface-variant);
   font-style: italic;
   padding: 16px;
 
   mat-icon {
-    color: #999;
+    color: var(--mat-sys-on-surface-variant);
   }
 }
 
@@ -66,17 +66,17 @@
 .claims-matrix-header {
   font-size: 12px;
   font-weight: 600;
-  color: #666;
+  color: var(--mat-sys-on-surface-variant);
   text-transform: uppercase;
   letter-spacing: 0.03em;
   padding: 4px 0;
-  border-bottom: 1px solid #ececec;
+  border-bottom: 1px solid var(--mat-sys-outline-variant);
 }
 
 .claims-matrix-row {
-  border: 1px solid #ececec;
+  border: 1px solid var(--mat-sys-outline-variant);
   border-radius: 6px;
-  background: #fafafa;
+  background: var(--mat-sys-surface-container);
   padding: 10px;
 }
 
@@ -93,14 +93,14 @@
   margin: 0;
   padding: 8px;
   border-radius: 4px;
-  border: 1px solid #e0e0e0;
-  background: #fff;
+  border: 1px solid var(--mat-sys-outline-variant);
+  background: var(--mat-sys-surface);
   font-size: 12px;
   overflow-x: auto;
 }
 
 .matrix-empty {
-  color: #999;
+  color: var(--mat-sys-on-surface-variant);
 }
 
 .matrix-label-list {
@@ -110,23 +110,23 @@
 }
 
 .disclosure-chip {
-  background-color: #f5f5f5;
-  color: #616161;
+  background-color: var(--mat-sys-surface-container-high);
+  color: var(--mat-sys-on-surface-variant);
 }
 
 .disclosure-chip-yes {
-  background-color: #e3f2fd;
-  color: #1565c0;
+  background-color: var(--mat-sys-primary-container);
+  color: var(--eudiplo-info);
 }
 
 .disclosure-chip-no {
-  background-color: #ffebee;
-  color: #c62828;
+  background-color: var(--mat-sys-error-container);
+  color: var(--eudiplo-danger);
 }
 
 .disclosure-chip-na {
-  background-color: #efebe9;
-  color: #6d4c41;
+  background-color: var(--mat-sys-tertiary-container);
+  color: var(--mat-sys-on-tertiary-container);
 }
 
 .loading-container {
@@ -150,7 +150,7 @@
   mat-list-item {
     height: auto !important;
     padding: 12px 0;
-    border-bottom: 1px solid #f0f0f0;
+    border-bottom: 1px solid var(--mat-sys-outline-variant);
 
     &:last-child {
       border-bottom: none;
@@ -170,13 +170,13 @@
 
 // Format chip styling
 .format-chip-sdjwt {
-  background-color: #e3f2fd !important;
-  color: #1565c0 !important;
+  background-color: var(--mat-sys-primary-container) !important;
+  color: var(--eudiplo-info) !important;
 }
 
 .format-chip-mdoc {
-  background-color: #e8f5e9 !important;
-  color: #2e7d32 !important;
+  background-color: var(--mat-sys-secondary-container) !important;
+  color: var(--eudiplo-success) !important;
 }
 
 // Credential preview styling
@@ -187,10 +187,10 @@
 
 // Claims metadata styling
 .claim-metadata-item {
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--mat-sys-outline-variant);
   border-radius: 4px;
   padding: 12px;
-  background-color: #fafafa;
+  background-color: var(--mat-sys-surface-container);
 
   .claim-header {
     margin-bottom: 8px;
@@ -199,7 +199,7 @@
 
   .claim-path {
     font-family: 'Roboto Mono', monospace;
-    word-break: break-word;
+    overflow-wrap: anywhere;
   }
 
   .claim-details-grid {
@@ -210,15 +210,15 @@
   }
 
   .claim-detail-item {
-    border: 1px solid #ececec;
+    border: 1px solid var(--mat-sys-outline-variant);
     border-radius: 4px;
-    background: #fff;
+    background: var(--mat-sys-surface);
     padding: 10px;
   }
 
   .detail-label {
     display: block;
-    color: #666;
+    color: var(--mat-sys-on-surface-variant);
     font-size: 12px;
     font-weight: 600;
     text-transform: uppercase;
@@ -230,29 +230,29 @@
     margin: 0;
     padding: 8px;
     border-radius: 4px;
-    border: 1px solid #e5e5e5;
-    background: #f7f7f7;
+    border: 1px solid var(--mat-sys-outline-variant);
+    background: var(--mat-sys-surface-container-high);
     font-size: 12px;
     overflow-x: auto;
   }
 
   .detail-text {
-    color: #333;
+    color: var(--mat-sys-on-surface);
   }
 
   .chip-mandatory {
-    background-color: #e8f5e9;
-    color: #2e7d32;
+    background-color: var(--mat-sys-secondary-container);
+    color: var(--eudiplo-success);
   }
 
   .chip-optional {
-    background-color: #fff8e1;
-    color: #8d6e63;
+    background-color: var(--mat-sys-tertiary-container);
+    color: var(--mat-sys-on-tertiary-container);
   }
 
   .chip-disclosable {
-    background-color: #e3f2fd;
-    color: #1565c0;
+    background-color: var(--mat-sys-primary-container);
+    color: var(--eudiplo-info);
   }
 
   .claim-display-list {
@@ -266,7 +266,7 @@
       padding: 4px 0;
 
       .locale-badge {
-        background-color: #e0e0e0;
+        background-color: var(--mat-sys-surface-container-high);
         padding: 2px 8px;
         border-radius: 4px;
         font-size: 12px;
@@ -291,7 +291,7 @@
   .credential-preview-media {
     border-radius: 12px;
     min-height: 160px;
-    border: 1px solid rgba(0, 0, 0, 0.08);
+    border: 1px solid var(--mat-sys-outline-variant);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     background-size: cover;
     background-position: center;
@@ -303,9 +303,9 @@
     gap: 12px;
     align-items: flex-start;
     padding: 12px;
-    border: 1px solid #ececec;
+    border: 1px solid var(--mat-sys-outline-variant);
     border-radius: 8px;
-    background-color: #fff;
+    background-color: var(--mat-sys-surface-container);
   }
 
   .preview-logo {
@@ -351,7 +351,7 @@ mat-card-header {
     gap: 8px;
 
     mat-icon {
-      color: #666;
+      color: var(--mat-sys-on-surface-variant);
     }
   }
 }
@@ -363,7 +363,7 @@ mat-expansion-panel-header {
     gap: 8px;
 
     mat-icon {
-      color: #666;
+      color: var(--mat-sys-on-surface-variant);
     }
   }
 }

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.scss
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.scss
@@ -6,7 +6,7 @@
 
 .option-description {
   font-size: 12px;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--mat-sys-on-surface-variant);
   margin-top: 2px;
 }
 
@@ -53,18 +53,18 @@ mat-form-field {
 
 // Form validation styles
 .mat-mdc-form-field.mat-form-field-invalid .mat-mdc-text-field-wrapper {
-  border-color: #f44336;
+  border-color: var(--eudiplo-danger);
 }
 
 // Readonly input styles
 input[readonly] {
-  color: rgba(0, 0, 0, 0.6);
-  background-color: rgba(0, 0, 0, 0.04);
+  color: var(--mat-sys-on-surface-variant);
+  background-color: var(--mat-sys-surface-container-high);
 }
 
 .toggle-description {
   font-size: 12px;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--mat-sys-on-surface-variant);
 }
 
 .trust-lists-section {
@@ -77,7 +77,7 @@ input[readonly] {
   align-items: center;
   gap: 8px;
   font-size: 13px;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--mat-sys-on-surface-variant);
 
   mat-icon {
     font-size: 18px;
@@ -91,27 +91,27 @@ input[readonly] {
   align-items: center;
   gap: 8px;
   font-size: 13px;
-  color: #f57c00;
+  color: var(--eudiplo-warning);
   padding: 8px;
-  background-color: rgba(255, 152, 0, 0.1);
+  background-color: var(--eudiplo-warning-subtle);
   border-radius: 4px;
 
   mat-icon {
     font-size: 18px;
     width: 18px;
     height: 18px;
-    color: #f57c00;
+    color: var(--eudiplo-warning);
   }
 }
 
 .trust-list-error {
   font-size: 12px;
-  color: var(--mdc-filled-text-field-error-label-text-color, #f44336);
+  color: var(--mdc-filled-text-field-error-label-text-color, var(--eudiplo-danger));
   margin: 4px 0 0 16px;
 }
 
 .chained-as-section {
-  background-color: rgba(103, 58, 183, 0.04);
+  background-color: var(--eudiplo-accent-subtle);
   border-radius: 0 4px 4px 0;
 
   h4 {
@@ -120,7 +120,7 @@ input[readonly] {
     gap: 8px;
     margin: 0 0 8px 0;
     font-weight: 500;
-    color: #673ab7;
+    color: var(--eudiplo-accent);
 
     mat-icon {
       font-size: 20px;
@@ -130,7 +130,7 @@ input[readonly] {
   }
 
   code {
-    background-color: rgba(0, 0, 0, 0.08);
+    background-color: var(--mat-sys-surface-container-high);
     padding: 2px 6px;
     border-radius: 4px;
     font-family: 'Roboto Mono', monospace;

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.scss
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.scss
@@ -1,10 +1,10 @@
 .value-text {
-  color: rgba(0, 0, 0, 0.7);
+  color: var(--mat-sys-on-surface-variant);
   margin-top: 4px;
   word-break: break-word;
 
   a {
-    color: #1976d2;
+    color: var(--eudiplo-info);
     text-decoration: none;
 
     &:hover {
@@ -14,8 +14,8 @@
 }
 
 .config-value {
-  background-color: #f5f5f5;
-  border: 1px solid #e0e0e0;
+  background-color: var(--mat-sys-surface-container);
+  border: 1px solid var(--mat-sys-outline-variant);
   border-radius: 4px;
   padding: 12px;
   margin-top: 8px;
@@ -29,7 +29,7 @@
 
 .binding-card {
   margin: 8px 0;
-  border-left: 4px solid #1976d2;
+  border-left: 4px solid var(--eudiplo-info);
 
   mat-card-content {
     padding: 16px !important;
@@ -40,7 +40,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--mat-sys-on-surface-variant);
   font-style: italic;
   padding: 16px;
 
@@ -65,7 +65,7 @@
   mat-list-item {
     height: auto !important;
     padding: 12px 0;
-    border-bottom: 1px solid #f0f0f0;
+    border-bottom: 1px solid var(--mat-sys-outline-variant);
 
     &:last-child {
       border-bottom: none;
@@ -74,26 +74,26 @@
 }
 
 .icon-disabled {
-  color: #9e9e9e;
+  color: var(--mat-sys-on-surface-variant);
 }
 
 .icon-chained-as {
-  color: #673ab7;
+  color: var(--eudiplo-accent);
 }
 
 .warning-text {
-  color: #f57c00;
+  color: var(--eudiplo-warning);
   font-weight: 500;
 }
 
 // Chained AS card styling
 .chained-as-card {
-  border-left: 4px solid #673ab7;
+  border-left: 4px solid var(--eudiplo-accent);
 
   mat-card-header {
     mat-card-title {
       mat-icon {
-        color: #673ab7;
+        color: var(--eudiplo-accent);
       }
     }
   }
@@ -157,13 +157,13 @@
   max-width: 200px;
   max-height: 100px;
   border-radius: 4px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--mat-sys-outline-variant);
   display: block;
 }
 
 .logo-url {
   font-size: 12px;
-  color: #666;
+  color: var(--mat-sys-on-surface-variant);
   margin-top: 4px;
   word-break: break-all;
 }

--- a/apps/client/src/app/issuance/issuance-offer/issuance-offer.component.scss
+++ b/apps/client/src/app/issuance/issuance-offer/issuance-offer.component.scss
@@ -8,13 +8,13 @@
 }
 
 ::ng-deep .claim-group {
-  border-left: 2px solid rgba(25, 118, 210, 0.18);
+  border-left: 2px solid var(--eudiplo-info-border);
   margin: 8px 0 12px;
   padding-left: 12px;
 }
 
 ::ng-deep .claim-group-header {
-  color: #0d47a1;
+  color: var(--eudiplo-info);
   font-size: 0.84rem;
   font-weight: 600;
   letter-spacing: 0.02em;
@@ -23,11 +23,11 @@
 }
 
 ::ng-deep .claim-group-header-level-2 {
-  color: #1565c0;
+  color: var(--eudiplo-info);
 }
 
 ::ng-deep .claim-group-header-level-3 {
-  color: #1976d2;
+  color: var(--eudiplo-info);
 }
 
 // Stepper styles
@@ -53,7 +53,7 @@
   }
 
   .step-description {
-    color: rgba(0, 0, 0, 0.6);
+    color: var(--mat-sys-on-surface-variant);
     margin-bottom: 24px;
   }
 }
@@ -61,7 +61,7 @@
 .step-actions {
   margin-top: 24px;
   padding-top: 16px;
-  border-top: 1px solid rgba(0, 0, 0, 0.12);
+  border-top: 1px solid var(--mat-sys-outline-variant);
 }
 
 // Flow selection styles
@@ -88,7 +88,7 @@
       margin-bottom: 4px;
 
       mat-icon {
-        color: #1976d2;
+        color: var(--eudiplo-info);
         font-size: 20px;
         width: 20px;
         height: 20px;
@@ -100,7 +100,7 @@
     }
 
     .flow-option-description {
-      color: rgba(0, 0, 0, 0.6);
+      color: var(--mat-sys-on-surface-variant);
       font-size: 0.875rem;
       margin: 0;
       padding-left: 28px;
@@ -113,9 +113,9 @@
 .iae-status-summary {
   margin-top: 24px;
   padding: 16px;
-  background-color: #fafafa;
+  background-color: var(--mat-sys-surface-container);
   border-radius: 8px;
-  border: 1px solid rgba(0, 0, 0, 0.12);
+  border: 1px solid var(--mat-sys-outline-variant);
 
   h4 {
     display: flex;
@@ -126,7 +126,7 @@
     font-weight: 500;
 
     mat-icon {
-      color: #1976d2;
+      color: var(--eudiplo-info);
     }
   }
 
@@ -139,18 +139,18 @@
     margin-bottom: 8px;
 
     &.success {
-      background-color: #e8f5e9;
+      background-color: var(--mat-sys-secondary-container);
 
       mat-icon {
-        color: #4caf50;
+        color: var(--eudiplo-success);
       }
     }
 
     &.warning {
-      background-color: #fff3e0;
+      background-color: var(--mat-sys-tertiary-container);
 
       mat-icon {
-        color: #ff9800;
+        color: var(--eudiplo-warning);
       }
     }
 
@@ -165,7 +165,7 @@
 
     .iae-hint {
       font-size: 0.75rem;
-      color: rgba(0, 0, 0, 0.6);
+      color: var(--mat-sys-on-surface-variant);
       margin: 4px 0 0 0;
     }
   }
@@ -180,20 +180,20 @@
     font-size: 0.875rem;
 
     &.success {
-      background-color: #e8f5e9;
-      color: #2e7d32;
+      background-color: var(--mat-sys-secondary-container);
+      color: var(--eudiplo-success);
 
       mat-icon {
-        color: #4caf50;
+        color: var(--eudiplo-success);
       }
     }
 
     &.info {
-      background-color: #e3f2fd;
-      color: #1565c0;
+      background-color: var(--mat-sys-primary-container);
+      color: var(--eudiplo-info);
 
       mat-icon {
-        color: #1976d2;
+        color: var(--eudiplo-info);
       }
     }
 
@@ -210,18 +210,18 @@
   display: flex;
   gap: 12px;
   padding: 16px;
-  background-color: #e3f2fd;
+  background-color: var(--mat-sys-primary-container);
   border-radius: 8px;
   margin-top: 16px;
 
   mat-icon {
-    color: #1976d2;
+    color: var(--eudiplo-info);
     flex-shrink: 0;
   }
 
   p {
     margin: 0;
-    color: #1565c0;
+    color: var(--eudiplo-info);
     line-height: 1.5;
   }
 }
@@ -231,13 +231,13 @@
   display: flex;
   gap: 16px;
   padding: 24px;
-  background-color: #e8f5e9;
+  background-color: var(--mat-sys-secondary-container);
   border-radius: 8px;
   border: 1px solid #a5d6a7;
   margin-bottom: 24px;
 
   .success-icon {
-    color: #4caf50;
+    color: var(--eudiplo-success);
     font-size: 48px;
     width: 48px;
     height: 48px;
@@ -246,14 +246,14 @@
 
   strong {
     font-size: 1.1rem;
-    color: #2e7d32;
+    color: var(--eudiplo-success);
     display: block;
     margin-bottom: 8px;
   }
 
   p {
     margin: 0;
-    color: #1b5e20;
+    color: var(--eudiplo-success);
     line-height: 1.5;
   }
 }
@@ -263,13 +263,13 @@
   display: flex;
   gap: 16px;
   padding: 24px;
-  background-color: #e3f2fd;
+  background-color: var(--mat-sys-primary-container);
   border-radius: 8px;
   border: 1px solid #90caf9;
   margin-bottom: 24px;
 
   .success-icon {
-    color: #1976d2;
+    color: var(--eudiplo-info);
     font-size: 48px;
     width: 48px;
     height: 48px;
@@ -278,14 +278,14 @@
 
   strong {
     font-size: 1.1rem;
-    color: #1565c0;
+    color: var(--eudiplo-info);
     display: block;
     margin-bottom: 8px;
   }
 
   p {
     margin: 0;
-    color: #0d47a1;
+    color: var(--eudiplo-info);
     line-height: 1.5;
   }
 }
@@ -316,7 +316,7 @@
       margin-bottom: 4px;
 
       mat-icon {
-        color: #1976d2;
+        color: var(--eudiplo-info);
         font-size: 20px;
         width: 20px;
         height: 20px;
@@ -328,7 +328,7 @@
     }
 
     .as-type-option-description {
-      color: rgba(0, 0, 0, 0.6);
+      color: var(--mat-sys-on-surface-variant);
       font-size: 0.875rem;
       margin: 0;
       padding-left: 28px;
@@ -344,9 +344,9 @@
 // Selected configs summary (for IAE flow step 3)
 .selected-configs-summary {
   padding: 16px;
-  background-color: #fafafa;
+  background-color: var(--mat-sys-surface-container);
   border-radius: 8px;
-  border: 1px solid rgba(0, 0, 0, 0.12);
+  border: 1px solid var(--mat-sys-outline-variant);
 
   h4 {
     margin: 0 0 12px 0;
@@ -364,14 +364,14 @@
       align-items: center;
       gap: 8px;
       padding: 8px 0;
-      border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+      border-bottom: 1px solid var(--mat-sys-outline-variant);
 
       &:last-child {
         border-bottom: none;
       }
 
       mat-icon {
-        color: #1976d2;
+        color: var(--eudiplo-info);
         font-size: 20px;
         width: 20px;
         height: 20px;
@@ -390,7 +390,7 @@
   font-weight: 500;
 
   mat-icon {
-    color: #1976d2;
+    color: var(--eudiplo-info);
   }
 }
 
@@ -410,7 +410,7 @@
       font-size: 1rem;
 
       mat-icon {
-        color: #1976d2;
+        color: var(--eudiplo-info);
       }
     }
   }
@@ -439,19 +439,19 @@
       font-size: 1rem;
 
       mat-icon {
-        color: #1976d2;
+        color: var(--eudiplo-info);
       }
     }
   }
 }
 
 .warn-hint {
-  color: #e65100 !important;
+  color: var(--eudiplo-warning) !important;
 }
 
 .iae-badge {
   font-size: 11px;
-  color: #1976d2;
+  color: var(--eudiplo-info);
   margin-left: 4px;
   font-weight: 500;
 }
@@ -461,13 +461,13 @@
   align-items: flex-start;
   gap: 8px;
   padding: 12px 16px;
-  background-color: #ffebee;
+  background-color: var(--mat-sys-error-container);
   border: 1px solid #ef9a9a;
   border-radius: 8px;
-  color: #c62828;
+  color: var(--eudiplo-danger);
 
   mat-icon {
-    color: #d32f2f;
+    color: var(--eudiplo-danger);
     flex-shrink: 0;
     margin-top: 2px;
   }
@@ -482,21 +482,21 @@
   align-items: center;
   gap: 8px;
   padding: 12px 16px;
-  background-color: #e3f2fd;
+  background-color: var(--mat-sys-primary-container);
   border-radius: 8px;
-  color: #1565c0;
+  color: var(--eudiplo-info);
 
   mat-icon {
-    color: #1976d2;
+    color: var(--eudiplo-info);
   }
 
   a {
-    color: #1565c0;
+    color: var(--eudiplo-info);
     font-weight: 500;
     text-decoration: underline;
 
     &:hover {
-      color: #0d47a1;
+      color: var(--eudiplo-info);
     }
   }
 }
@@ -513,7 +513,7 @@
   display: block;
   font-weight: 500;
   margin-bottom: 12px;
-  color: rgba(0, 0, 0, 0.87);
+  color: var(--mat-sys-on-surface-variant);
 }
 
 .radio-option {
@@ -530,7 +530,7 @@
   gap: 12px;
 
   mat-icon {
-    color: rgba(0, 0, 0, 0.54);
+    color: var(--mat-sys-on-surface-variant);
   }
 }
 
@@ -541,7 +541,7 @@
 
 .radio-description {
   font-size: 12px;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--mat-sys-on-surface-variant);
 }
 
 .preview-card {
@@ -561,11 +561,11 @@
 
   strong {
     font-weight: 500;
-    color: rgba(0, 0, 0, 0.87);
+    color: var(--mat-sys-on-surface-variant);
   }
 
   span {
-    color: rgba(0, 0, 0, 0.6);
+    color: var(--mat-sys-on-surface-variant);
   }
 }
 
@@ -578,27 +578,27 @@
 
 .credential-item {
   padding: 8px 12px;
-  background-color: #f5f5f5;
+  background-color: var(--mat-sys-surface-container);
   border-radius: 4px;
   font-size: 13px;
-  color: rgba(0, 0, 0, 0.7);
+  color: var(--mat-sys-on-surface-variant);
 }
 
 .result-card {
-  background: linear-gradient(135deg, #e8f5e8 0%, #f0f9ff 100%);
-  border: 1px solid #4caf50;
+  background: linear-gradient(135deg, var(--mat-sys-secondary-container) 0%, #f0f9ff 100%);
+  border: 1px solid var(--eudiplo-success);
   margin-top: 24px;
 
   mat-card-header {
-    background: rgba(76, 175, 80, 0.1);
+    background: var(--eudiplo-success-soft);
     //margin: -16px -16px 16px -16px;
     padding: 16px;
 
     mat-card-title {
-      color: #2e7d32;
+      color: var(--eudiplo-success);
 
       mat-icon {
-        color: #4caf50;
+        color: var(--eudiplo-success);
         margin-right: 8px;
       }
     }
@@ -616,7 +616,7 @@
     display: block;
     font-weight: 500;
     margin-bottom: 8px;
-    color: rgba(0, 0, 0, 0.87);
+    color: var(--mat-sys-on-surface-variant);
   }
 }
 
@@ -625,7 +625,7 @@
   align-items: center;
   gap: 8px;
   padding: 12px;
-  background-color: #f8f9fa;
+  background-color: var(--mat-sys-surface-container);
   border: 1px solid #e9ecef;
   border-radius: 4px;
 
@@ -633,7 +633,7 @@
     flex: 1;
     font-family: 'Courier New', monospace;
     font-size: 14px;
-    color: #495057;
+    color: var(--mat-sys-on-surface-variant);
     word-break: break-all;
 
     &.uri-value {
@@ -654,7 +654,7 @@
     display: block;
     font-weight: 500;
     margin-bottom: 12px;
-    color: rgba(0, 0, 0, 0.87);
+    color: var(--mat-sys-on-surface-variant);
   }
 }
 
@@ -662,8 +662,8 @@
   display: flex;
   justify-content: center;
   padding: 20px;
-  background-color: #ffffff;
-  border: 1px solid #e0e0e0;
+  background-color: var(--mat-sys-on-error);
+  border: 1px solid var(--mat-sys-outline-variant);
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 
@@ -681,22 +681,22 @@
   align-items: center;
   justify-content: center;
   padding: 40px;
-  border: 2px dashed #ccc;
+  border: 2px dashed var(--mat-sys-outline-variant);
   border-radius: 8px;
-  background-color: #fafafa;
+  background-color: var(--mat-sys-surface-container);
   text-align: center;
 
   mat-icon {
     font-size: 48px;
     width: 48px;
     height: 48px;
-    color: #ccc;
+    color: var(--mat-sys-outline-variant);
     margin-bottom: 16px;
   }
 
   p {
     margin: 0;
-    color: rgba(0, 0, 0, 0.6);
+    color: var(--mat-sys-on-surface-variant);
   }
 }
 
@@ -715,18 +715,18 @@
       font-size: 64px;
       width: 64px;
       height: 64px;
-      color: #ff9800;
+      color: var(--eudiplo-warning);
       margin-bottom: 16px;
     }
 
     h3 {
       margin: 16px 0 8px 0;
-      color: rgba(0, 0, 0, 0.87);
+      color: var(--mat-sys-on-surface-variant);
     }
 
     p {
       margin: 0 0 24px 0;
-      color: rgba(0, 0, 0, 0.6);
+      color: var(--mat-sys-on-surface-variant);
     }
   }
 }
@@ -751,13 +751,13 @@
 
   // Success snackbar styling
   .success-snackbar {
-    --mdc-snackbar-container-color: #4caf50;
+    --mdc-snackbar-container-color: var(--eudiplo-success);
     --mdc-snackbar-supporting-text-color: white;
   }
 
   // Error snackbar styling
   .error-snackbar {
-    --mdc-snackbar-container-color: #f44336;
+    --mdc-snackbar-container-color: var(--eudiplo-danger);
     --mdc-snackbar-supporting-text-color: white;
   }
 }
@@ -779,23 +779,23 @@
   min-width: 70px;
 
   &.status-active {
-    background-color: #e8f5e8;
-    color: #2e7d32;
+    background-color: var(--mat-sys-secondary-container);
+    color: var(--eudiplo-success);
   }
 
   &.status-completed {
-    background-color: #e3f2fd;
-    color: #1976d2;
+    background-color: var(--mat-sys-primary-container);
+    color: var(--eudiplo-info);
   }
 
   &.status-expired {
-    background-color: #fff3e0;
-    color: #f57c00;
+    background-color: var(--mat-sys-tertiary-container);
+    color: var(--eudiplo-warning);
   }
 
   &.status-failed {
-    background-color: #ffebee;
-    color: #d32f2f;
+    background-color: var(--mat-sys-error-container);
+    color: var(--eudiplo-danger);
   }
 }
 
@@ -804,7 +804,7 @@
   align-items: center;
   gap: 4px;
   font-size: 12px;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--mat-sys-on-surface-variant);
 
   .spinning {
     font-size: 16px;
@@ -831,10 +831,10 @@
 .credential-section {
   padding: 16px;
   border-radius: 8px;
-  background-color: rgba(0, 0, 0, 0.02);
+  background-color: var(--mat-sys-surface-container-low);
 
   &:hover {
-    background-color: rgba(0, 0, 0, 0.04);
+    background-color: var(--mat-sys-surface-container-high);
   }
 }
 
@@ -849,24 +849,24 @@
   font-size: 18px;
   font-weight: 500;
   margin: 0;
-  color: rgba(0, 0, 0, 0.87);
+  color: var(--mat-sys-on-surface-variant);
 
   mat-icon {
-    color: #1976d2;
+    color: var(--eudiplo-info);
   }
 }
 
 .claim-source-selection {
   padding: 16px;
   border-radius: 4px;
-  background-color: #fff;
-  border: 1px solid rgba(0, 0, 0, 0.12);
+  background-color: var(--mat-sys-on-error);
+  border: 1px solid var(--mat-sys-outline-variant);
 
   .source-label {
     display: block;
     font-weight: 500;
     margin-bottom: 12px;
-    color: rgba(0, 0, 0, 0.87);
+    color: var(--mat-sys-on-surface-variant);
   }
 
   mat-radio-group {
@@ -906,38 +906,38 @@
   }
 
   &.info {
-    background-color: #e3f2fd;
-    color: #1565c0;
-    border-left: 3px solid #1976d2;
+    background-color: var(--mat-sys-primary-container);
+    color: var(--eudiplo-info);
+    border-left: 3px solid var(--eudiplo-info);
 
     mat-icon {
-      color: #1976d2;
+      color: var(--eudiplo-info);
     }
   }
 
   &.warning {
-    background-color: #fff3e0;
-    color: #e65100;
-    border-left: 3px solid #ff9800;
+    background-color: var(--mat-sys-tertiary-container);
+    color: var(--eudiplo-warning);
+    border-left: 3px solid var(--eudiplo-warning);
 
     mat-icon {
-      color: #ff9800;
+      color: var(--eudiplo-warning);
     }
   }
 }
 
 .webhook-info {
   padding: 16px;
-  background-color: #fff;
+  background-color: var(--mat-sys-on-error);
   border-radius: 4px;
-  border: 1px solid rgba(0, 0, 0, 0.12);
+  border: 1px solid var(--mat-sys-outline-variant);
 }
 
 .form-input {
   padding: 16px;
-  background-color: #fff;
+  background-color: var(--mat-sys-on-error);
   border-radius: 4px;
-  border: 1px solid rgba(0, 0, 0, 0.12);
+  border: 1px solid var(--mat-sys-outline-variant);
 }
 
 .pre-config-button {

--- a/apps/client/src/app/key-management/key-management-create/key-download-dialog/key-download-dialog.component.scss
+++ b/apps/client/src/app/key-management/key-management-create/key-download-dialog/key-download-dialog.component.scss
@@ -1,7 +1,7 @@
 .dialog-icon {
   vertical-align: middle;
   margin-right: 8px;
-  color: #ff9800;
+  color: var(--eudiplo-warning);
 }
 
 .warning-banner {
@@ -9,20 +9,20 @@
   align-items: flex-start;
   gap: 12px;
   padding: 16px;
-  background-color: #fff3e0;
-  border-left: 4px solid #ff9800;
+  background-color: var(--mat-sys-tertiary-container);
+  border-left: 4px solid var(--eudiplo-warning);
   border-radius: 4px;
   margin-bottom: 16px;
 }
 
 .warning-banner mat-icon {
-  color: #ff9800;
+  color: var(--eudiplo-warning);
   flex-shrink: 0;
 }
 
 .warning-banner p {
   margin: 4px 0 0 0;
-  color: #666;
+  color: var(--mat-sys-on-surface-variant);
 }
 
 h4 {

--- a/apps/client/src/app/key-management/key-management-create/key-management-create.component.scss
+++ b/apps/client/src/app/key-management/key-management-create/key-management-create.component.scss
@@ -1,9 +1,9 @@
 .info-card {
-  background-color: #f5f5f5;
+  background-color: var(--mat-sys-surface-container);
   margin: 16px 0;
 
   .info-icon {
-    color: #666;
+    color: var(--mat-sys-on-surface-variant);
   }
 
   mat-card-content {
@@ -13,13 +13,13 @@
 
 ::ng-deep {
   .provider-type {
-    color: #666;
+    color: var(--mat-sys-on-surface-variant);
     font-size: 0.9em;
     margin-left: 4px;
   }
 
   .provider-default {
-    color: #1976d2;
+    color: var(--eudiplo-info);
     font-weight: 500;
   }
 
@@ -36,27 +36,27 @@
 
   .provider-description {
     font-size: 0.85em;
-    color: #666;
+    color: var(--mat-sys-on-surface-variant);
     margin-top: 2px;
   }
 }
 
 .certificate-item {
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--mat-sys-outline-variant);
   padding: 16px;
   border-radius: 4px;
-  background-color: #fafafa;
+  background-color: var(--mat-sys-surface-container);
 }
 
 .cert-header {
   margin: 0;
-  color: #333;
+  color: var(--mat-sys-on-surface);
   font-weight: 500;
 }
 
 .cert-pem-header {
   margin: 8px 0 0 0;
-  color: #333;
+  color: var(--mat-sys-on-surface);
   font-weight: 500;
 }
 
@@ -65,7 +65,7 @@
 }
 
 .info-text {
-  color: #999;
+  color: var(--mat-sys-on-surface-variant);
   font-style: italic;
   margin: 0;
 }

--- a/apps/client/src/app/key-management/key-management-show/key-management-show.component.scss
+++ b/apps/client/src/app/key-management/key-management-show/key-management-show.component.scss
@@ -1,5 +1,5 @@
 .delete-button {
-  color: #f44336;
+  color: var(--eudiplo-danger);
 }
 
 .spacer {
@@ -18,11 +18,11 @@
   td {
     padding: 8px 16px 8px 0;
     vertical-align: top;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+    border-bottom: 1px solid var(--mat-sys-outline-variant);
 
     &:first-child {
       width: 150px;
-      color: rgba(0, 0, 0, 0.6);
+      color: var(--mat-sys-on-surface-variant);
     }
 
     &:last-child {
@@ -34,13 +34,13 @@
 .cert-pem-section {
   h4 {
     margin-bottom: 12px;
-    color: rgba(0, 0, 0, 0.87);
+    color: var(--mat-sys-on-surface-variant);
   }
 }
 
 .pem-container {
-  background-color: #f5f5f5;
-  border: 1px solid #e0e0e0;
+  background-color: var(--mat-sys-surface-container);
+  border: 1px solid var(--mat-sys-outline-variant);
   border-radius: 4px;
   padding: 16px;
   max-height: 300px;
@@ -54,18 +54,18 @@
   margin: 0;
   white-space: pre-wrap;
   word-break: break-all;
-  color: #333;
+  color: var(--mat-sys-on-surface);
 }
 
 .no-cert-message {
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--mat-sys-on-surface-variant);
   font-style: italic;
   text-align: center;
   padding: 32px 0;
 }
 
 h4 {
-  color: #1976d2;
+  color: var(--eudiplo-info);
   margin-bottom: 16px;
   font-weight: 500;
 }
@@ -76,11 +76,11 @@ h4 {
   font-size: 18px;
 
   &.valid {
-    color: #4caf50;
+    color: var(--eudiplo-success);
   }
 
   &.expired {
-    color: #f44336;
+    color: var(--eudiplo-danger);
   }
 }
 
@@ -90,26 +90,26 @@ h4 {
   margin-left: 4px;
 
   &.valid {
-    color: #4caf50;
+    color: var(--eudiplo-success);
   }
 
   &.expired {
-    color: #f44336;
+    color: var(--eudiplo-danger);
   }
 }
 
 .expired {
-  color: #f44336;
+  color: var(--eudiplo-danger);
 }
 
 .valid {
-  color: #4caf50;
+  color: var(--eudiplo-success);
 }
 
 .key-usage-tag {
   display: inline-block;
-  background-color: #e3f2fd;
-  color: #1976d2;
+  background-color: var(--mat-sys-primary-container);
+  color: var(--eudiplo-info);
   padding: 2px 8px;
   margin: 2px 4px 2px 0;
   border-radius: 12px;
@@ -119,8 +119,8 @@ h4 {
 
 .usage-tag {
   display: inline-block;
-  background-color: #f3e5f5;
-  color: #7b1fa2;
+  background-color: var(--mat-sys-tertiary-container);
+  color: var(--eudiplo-accent);
   padding: 2px 8px;
   margin: 2px 4px 2px 0;
   border-radius: 12px;
@@ -150,7 +150,7 @@ h4 {
 
   code {
     font-size: 12px;
-    background-color: rgba(0, 0, 0, 0.05);
+    background-color: var(--mat-sys-surface-container-high);
     padding: 2px 6px;
     border-radius: 4px;
   }
@@ -161,7 +161,7 @@ h4 {
   transition: background-color 0.2s;
 
   &:hover {
-    background-color: rgba(0, 0, 0, 0.04);
+    background-color: var(--mat-sys-surface-container-high);
   }
 }
 
@@ -173,11 +173,11 @@ h4 {
     font-size: 64px;
     width: 64px;
     height: 64px;
-    color: rgba(0, 0, 0, 0.26);
+    color: var(--mat-sys-on-surface-variant);
   }
 
   p {
-    color: rgba(0, 0, 0, 0.54);
+    color: var(--mat-sys-on-surface-variant);
     margin: 0;
   }
 }
@@ -193,7 +193,7 @@ mat-chip {
 
 // Key Type Card Styles
 .key-type-card {
-  background-color: var(--mat-sys-surface-container-lowest, #fafafa);
+  background-color: var(--mat-sys-surface-container-lowest, var(--mat-sys-surface-container));
 
   .key-type-icon {
     width: 56px;
@@ -211,18 +211,18 @@ mat-chip {
     }
 
     &.root-ca {
-      background-color: var(--mat-sys-primary-container, #e3f2fd);
+      background-color: var(--mat-sys-primary-container, var(--mat-sys-primary-container));
 
       mat-icon {
-        color: var(--mat-sys-on-primary-container, #1565c0);
+        color: var(--mat-sys-on-primary-container, var(--eudiplo-info));
       }
     }
 
     &.signing {
-      background-color: var(--mat-sys-secondary-container, #e8f5e9);
+      background-color: var(--mat-sys-secondary-container, var(--mat-sys-secondary-container));
 
       mat-icon {
-        color: var(--mat-sys-on-secondary-container, #2e7d32);
+        color: var(--mat-sys-on-secondary-container, var(--eudiplo-success));
       }
     }
 
@@ -230,20 +230,20 @@ mat-chip {
       background-color: var(--mat-sys-tertiary-container, #fff3e0);
 
       mat-icon {
-        color: var(--mat-sys-on-tertiary-container, #e65100);
+        color: var(--mat-sys-on-tertiary-container, var(--eudiplo-warning));
       }
     }
 
     &.internalChain {
-      background-color: var(--mat-sys-primary-container, #e3f2fd);
+      background-color: var(--mat-sys-primary-container, var(--mat-sys-primary-container));
 
       mat-icon {
-        color: var(--mat-sys-on-primary-container, #1565c0);
+        color: var(--mat-sys-on-primary-container, var(--eudiplo-info));
       }
     }
 
     &.legacy {
-      background-color: var(--mat-sys-error-container, #ffebee);
+      background-color: var(--mat-sys-error-container, var(--mat-sys-error-container));
 
       mat-icon {
         color: var(--mat-sys-on-error-container, #b71c1c);
@@ -254,12 +254,12 @@ mat-chip {
   .key-type-label {
     font-size: 1.25rem;
     font-weight: 500;
-    color: var(--mat-sys-on-surface, rgba(0, 0, 0, 0.87));
+    color: var(--mat-sys-on-surface);
   }
 
   .key-type-description {
     font-size: 0.875rem;
-    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+    color: var(--mat-sys-on-surface-variant);
     margin-top: 4px;
   }
 }
@@ -268,14 +268,14 @@ mat-chip {
 .key-chain-section {
   margin-top: 24px;
   padding-top: 16px;
-  border-top: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.12));
+  border-top: 1px solid var(--mat-sys-outline-variant, var(--mat-sys-outline-variant));
 
   .chain-label {
     font-size: 0.75rem;
     font-weight: 500;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+    color: var(--mat-sys-on-surface-variant);
     margin-bottom: 12px;
   }
 }
@@ -294,18 +294,18 @@ mat-chip {
   transition: background-color 0.2s;
 
   &:hover {
-    background-color: var(--mat-sys-surface-container, rgba(0, 0, 0, 0.04));
+    background-color: var(--mat-sys-surface-container);
   }
 
   &.current {
-    background-color: var(--mat-sys-surface-container-high, rgba(0, 0, 0, 0.08));
+    background-color: var(--mat-sys-surface-container-high);
   }
 
   .chain-connector {
     position: absolute;
     left: 36px;
     width: 2px;
-    background-color: var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.12));
+    background-color: var(--mat-sys-outline-variant);
 
     &.up {
       top: -8px;
@@ -335,18 +335,18 @@ mat-chip {
   }
 
   &.parent {
-    background-color: var(--mat-sys-primary-container, #e3f2fd);
+    background-color: var(--mat-sys-primary-container, var(--mat-sys-primary-container));
 
     mat-icon {
-      color: var(--mat-sys-on-primary-container, #1565c0);
+      color: var(--mat-sys-on-primary-container, var(--eudiplo-info));
     }
   }
 
   &.current {
-    background-color: var(--mat-sys-secondary-container, #e8f5e9);
+    background-color: var(--mat-sys-secondary-container, var(--mat-sys-secondary-container));
 
     mat-icon {
-      color: var(--mat-sys-on-secondary-container, #2e7d32);
+      color: var(--mat-sys-on-secondary-container, var(--eudiplo-success));
     }
   }
 
@@ -354,13 +354,13 @@ mat-chip {
     background-color: var(--mat-sys-tertiary-container, #fff3e0);
 
     mat-icon {
-      color: var(--mat-sys-on-tertiary-container, #e65100);
+      color: var(--mat-sys-on-tertiary-container, var(--eudiplo-warning));
     }
   }
 }
 
 .chain-key-link {
-  color: var(--mat-sys-primary, #1976d2);
+  color: var(--mat-sys-primary, var(--eudiplo-info));
   text-decoration: none;
   font-weight: 500;
 
@@ -371,10 +371,10 @@ mat-chip {
 
 .chain-key-name {
   font-weight: 500;
-  color: var(--mat-sys-on-surface, rgba(0, 0, 0, 0.87));
+  color: var(--mat-sys-on-surface);
 }
 
 .chain-key-role {
   font-size: 0.8rem;
-  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+  color: var(--mat-sys-on-surface-variant);
 }

--- a/apps/client/src/app/login/login.component.scss
+++ b/apps/client/src/app/login/login.component.scss
@@ -12,8 +12,8 @@
   flex: 1;
   width: 100%;
   background:
-    radial-gradient(circle at top, rgba(255, 255, 255, 0.18), transparent 32%),
-    linear-gradient(145deg, #1d4e89 0%, #153b63 50%, #0d2238 100%);
+    radial-gradient(circle at top, color-mix(in srgb, white 18%, transparent), transparent 32%),
+    linear-gradient(145deg, var(--eudiplo-info) 0%, #153b63 50%, #0d2238 100%);
   padding: 24px;
 }
 
@@ -23,7 +23,7 @@
   padding: 28px 28px 20px;
   box-shadow: 0 24px 60px rgba(4, 18, 31, 0.28);
   border-radius: 24px;
-  border: 1px solid rgba(10, 39, 64, 0.08);
+  border: 1px solid var(--eudiplo-info-subtle);
 }
 
 .brand-header {
@@ -41,8 +41,8 @@
   width: 84px;
   height: 84px;
   border-radius: 22px;
-  background: linear-gradient(180deg, rgba(29, 78, 137, 0.12), rgba(29, 78, 137, 0.03));
-  border: 1px solid rgba(29, 78, 137, 0.12);
+  background: linear-gradient(180deg, var(--eudiplo-info-soft), var(--eudiplo-info-subtle));
+  border: 1px solid var(--eudiplo-info-border);
 }
 
 .brand-copy {
@@ -58,7 +58,7 @@
 }
 
 .eyebrow {
-  color: #1d4e89;
+  color: var(--eudiplo-info);
   text-transform: uppercase;
   letter-spacing: 0.12em;
   font-size: 12px;
@@ -66,14 +66,14 @@
 }
 
 .brand-title {
-  color: #10233a;
+  color: var(--mat-sys-on-surface);
   font-size: 34px;
   line-height: 1;
   font-weight: 700;
 }
 
 .brand-subtitle {
-  color: rgba(16, 35, 58, 0.72);
+  color: var(--mat-sys-on-surface-variant);
   line-height: 1.5;
 }
 
@@ -84,8 +84,8 @@
 }
 
 .dev-indicator {
-  color: #9a6700;
-  background: rgba(255, 152, 0, 0.12);
+  color: var(--eudiplo-warning);
+  background: var(--eudiplo-warning-soft);
   border-radius: 999px;
   padding: 6px 10px;
   font-weight: 600;
@@ -119,17 +119,17 @@
 }
 
 .mode-description {
-  color: rgba(16, 35, 58, 0.76);
+  color: var(--mat-sys-on-surface-variant);
   line-height: 1.5;
 }
 
 .mode-hint {
-  color: rgba(16, 35, 58, 0.58);
+  color: var(--mat-sys-on-surface-variant);
   font-size: 14px;
 }
 
 .mode-hint-warning {
-  color: #c62828;
+  color: var(--eudiplo-danger);
 }
 
 .full-width {
@@ -159,12 +159,12 @@
 
 // Custom snackbar styles
 ::ng-deep .success-snackbar {
-  background-color: #4caf50 !important;
+  background-color: var(--eudiplo-success) !important;
   color: white !important;
 }
 
 ::ng-deep .error-snackbar {
-  background-color: #f44336 !important;
+  background-color: var(--eudiplo-danger) !important;
   color: white !important;
 }
 

--- a/apps/client/src/app/presentation/presentation-config/issuer-metadata-browser/issuer-metadata-browser.component.scss
+++ b/apps/client/src/app/presentation/presentation-config/issuer-metadata-browser/issuer-metadata-browser.component.scss
@@ -9,12 +9,12 @@ mat-dialog-content {
 }
 
 .error-card {
-  background-color: #ffebee;
-  color: #c62828;
+  background-color: var(--mat-sys-error-container);
+  color: var(--eudiplo-danger);
 }
 
 .issuer-info-card {
-  background-color: #f5f5f5;
+  background-color: var(--mat-sys-surface-container);
 
   .issuer-logo {
     width: 48px;
@@ -24,7 +24,7 @@ mat-dialog-content {
   }
 
   .issuer-url {
-    color: rgba(0, 0, 0, 0.6);
+    color: var(--mat-sys-on-surface-variant);
     font-family: monospace;
     font-size: 12px;
   }
@@ -41,7 +41,7 @@ mat-dialog-content {
   padding: 8px 0;
 
   .description {
-    color: rgba(0, 0, 0, 0.7);
+    color: var(--mat-sys-on-surface-variant);
     margin: 0;
   }
 
@@ -54,7 +54,7 @@ mat-dialog-content {
     code {
       font-family: monospace;
       font-size: 12px;
-      background-color: #f5f5f5;
+      background-color: var(--mat-sys-surface-container);
       padding: 2px 6px;
       border-radius: 4px;
     }
@@ -75,10 +75,10 @@ mat-dialog-content {
 .claim-item {
   padding: 8px;
   border-radius: 4px;
-  background-color: #fafafa;
+  background-color: var(--mat-sys-surface-container);
 
   &:hover {
-    background-color: #f0f0f0;
+    background-color: var(--mat-sys-outline-variant);
   }
 
   .claim-name {
@@ -86,7 +86,7 @@ mat-dialog-content {
   }
 
   .claim-path {
-    color: rgba(0, 0, 0, 0.6);
+    color: var(--mat-sys-on-surface-variant);
     font-family: monospace;
     font-size: 11px;
   }
@@ -96,20 +96,20 @@ mat-dialog-content {
     min-height: 18px;
     padding: 0 6px;
     margin-left: 4px;
-    background-color: #fff3e0;
-    color: #e65100;
+    background-color: var(--mat-sys-tertiary-container);
+    color: var(--eudiplo-warning);
   }
 }
 
 .no-claims {
-  color: rgba(0, 0, 0, 0.5);
+  color: var(--mat-sys-on-surface-variant);
   font-style: italic;
   margin: 0;
 }
 
 .dcql-preview {
-  background-color: #263238;
-  color: #aed581;
+  background-color: var(--mat-sys-surface-container-highest);
+  color: var(--eudiplo-success);
   padding: 16px;
   border-radius: 8px;
   font-family: monospace;

--- a/apps/client/src/app/presentation/presentation-config/presentation-show/presentation-show.component.scss
+++ b/apps/client/src/app/presentation/presentation-config/presentation-show/presentation-show.component.scss
@@ -5,7 +5,7 @@
   mat-list-item {
     height: auto !important;
     padding: 12px 0;
-    border-bottom: 1px solid #f0f0f0;
+    border-bottom: 1px solid var(--mat-sys-outline-variant);
 
     &:last-child {
       border-bottom: none;
@@ -14,17 +14,17 @@
 }
 
 .icon-enabled {
-  color: #2e7d32;
+  color: var(--eudiplo-success);
 }
 
 .icon-disabled {
-  color: #9e9e9e;
+  color: var(--mat-sys-on-surface-variant);
 }
 
 // Config value (JSON) styling
 .config-value {
-  background-color: #f5f5f5;
-  border: 1px solid #e0e0e0;
+  background-color: var(--mat-sys-surface-container);
+  border: 1px solid var(--mat-sys-outline-variant);
   border-radius: 4px;
   padding: 12px;
   margin: 0;
@@ -38,7 +38,7 @@
 
 // Credential query card styling
 .credential-query-card {
-  border-left: 4px solid #1976d2;
+  border-left: 4px solid var(--eudiplo-info);
 
   mat-card-header {
     padding-bottom: 8px;
@@ -48,7 +48,7 @@
 .query-meta {
   margin-bottom: 16px;
   padding: 12px;
-  background-color: #f5f5f5;
+  background-color: var(--mat-sys-surface-container);
   border-radius: 4px;
 
   div {
@@ -66,13 +66,13 @@
 
 // Format chip styling
 .format-sdjwt {
-  background-color: #e3f2fd !important;
-  color: #1565c0 !important;
+  background-color: var(--mat-sys-primary-container) !important;
+  color: var(--eudiplo-info) !important;
 }
 
 .format-mdoc {
-  background-color: #e8f5e9 !important;
-  color: #2e7d32 !important;
+  background-color: var(--mat-sys-secondary-container) !important;
+  color: var(--eudiplo-success) !important;
 }
 
 // Credential Sets section styling
@@ -87,26 +87,26 @@
     margin: 0 0 8px 0;
     font-size: 16px;
     font-weight: 500;
-    color: #333;
+    color: var(--mat-sys-on-surface);
 
     mat-icon {
       font-size: 20px;
       width: 20px;
       height: 20px;
-      color: #666;
+      color: var(--mat-sys-on-surface-variant);
     }
   }
 
   .section-description {
     margin: 0 0 16px 0;
-    color: #666;
+    color: var(--mat-sys-on-surface-variant);
     font-size: 14px;
   }
 }
 
 .credential-set-card {
-  background-color: #fafafa;
-  border: 1px solid #e0e0e0;
+  background-color: var(--mat-sys-surface-container);
+  border: 1px solid var(--mat-sys-outline-variant);
   border-radius: 8px;
   padding: 16px;
 
@@ -118,13 +118,13 @@
 
     .set-label {
       font-weight: 500;
-      color: #1976d2;
+      color: var(--eudiplo-info);
     }
   }
 
   .required-chip {
-    background-color: #fff3e0 !important;
-    color: #bf360c !important;
+    background-color: var(--mat-sys-tertiary-container) !important;
+    color: var(--eudiplo-warning) !important;
     font-size: 11px;
   }
 
@@ -136,28 +136,28 @@
 
     .or-separator {
       font-weight: 500;
-      color: #9e9e9e;
+      color: var(--mat-sys-on-surface-variant);
       padding: 0 4px;
     }
 
     .and-separator {
       font-weight: 500;
-      color: #666;
+      color: var(--mat-sys-on-surface-variant);
     }
 
     .option-group {
       display: flex;
       align-items: center;
       gap: 4px;
-      background-color: #fff;
-      border: 1px solid #e0e0e0;
+      background-color: var(--mat-sys-on-error);
+      border: 1px solid var(--mat-sys-outline-variant);
       border-radius: 16px;
       padding: 4px 8px;
     }
 
     .credential-id-chip {
-      background-color: #e3f2fd !important;
-      color: #1565c0 !important;
+      background-color: var(--mat-sys-primary-container) !important;
+      color: var(--eudiplo-info) !important;
       font-size: 12px;
     }
   }
@@ -179,7 +179,7 @@ mat-card-header {
     font-weight: 500;
 
     mat-icon {
-      color: #666;
+      color: var(--mat-sys-on-surface-variant);
     }
   }
 }
@@ -199,7 +199,7 @@ mat-expansion-panel {
 
 // Empty state styling
 .empty-state {
-  color: #999;
+  color: var(--mat-sys-on-surface-variant);
   text-align: center;
   padding: 48px;
 
@@ -207,7 +207,7 @@ mat-expansion-panel {
     font-size: 64px;
     width: 64px;
     height: 64px;
-    color: #ccc;
+    color: var(--mat-sys-outline-variant);
     margin-bottom: 16px;
   }
 
@@ -221,7 +221,7 @@ mat-expansion-panel {
 .trusted-authorities {
   margin-top: 16px;
   padding: 12px;
-  background-color: #f5f5f5;
+  background-color: var(--mat-sys-surface-container);
   border-radius: 4px;
 
   h5 {
@@ -231,13 +231,13 @@ mat-expansion-panel {
     margin: 0 0 12px 0;
     font-size: 14px;
     font-weight: 500;
-    color: #333;
+    color: var(--mat-sys-on-surface);
 
     mat-icon {
       font-size: 18px;
       width: 18px;
       height: 18px;
-      color: #2e7d32;
+      color: var(--eudiplo-success);
     }
   }
 
@@ -252,8 +252,8 @@ mat-expansion-panel {
     }
 
     .authority-type {
-      background-color: #e8f5e9 !important;
-      color: #2e7d32 !important;
+      background-color: var(--mat-sys-secondary-container) !important;
+      color: var(--eudiplo-success) !important;
       font-size: 11px;
       text-transform: uppercase;
     }
@@ -268,10 +268,10 @@ mat-expansion-panel {
     .authority-value {
       font-family: 'Roboto Mono', monospace;
       font-size: 12px;
-      background-color: #fff;
+      background-color: var(--mat-sys-on-error);
       padding: 4px 8px;
       border-radius: 4px;
-      border: 1px solid #e0e0e0;
+      border: 1px solid var(--mat-sys-outline-variant);
       word-break: break-all;
     }
   }

--- a/apps/client/src/app/presentation/presentation-config/schema-metadata-browser/schema-metadata-browser.component.scss
+++ b/apps/client/src/app/presentation/presentation-config/schema-metadata-browser/schema-metadata-browser.component.scss
@@ -1,5 +1,5 @@
 .dcql-preview {
-  background: #f6f7f9;
+  background: var(--mat-sys-surface-container-low);
   border: 1px solid #d8dce3;
   border-radius: 8px;
   padding: 12px;
@@ -10,7 +10,7 @@
 }
 
 .json-preview {
-  background: #fafbfc;
+  background: var(--mat-sys-surface-container);
   border: 1px solid #e1e4e8;
   border-radius: 6px;
   padding: 8px;
@@ -30,7 +30,7 @@
 }
 
 .subtle {
-  color: rgba(0, 0, 0, 0.58);
+  color: var(--mat-sys-on-surface-variant);
   font-size: 12px;
 }
 
@@ -52,7 +52,7 @@
 }
 
 .error-card {
-  border-left: 4px solid #d32f2f;
+  border-left: 4px solid var(--eudiplo-danger);
 }
 
 .catalog-list-item {
@@ -66,12 +66,12 @@
 
 .catalog-meta {
   font-size: 12px;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--mat-sys-on-surface-variant);
 }
 
 .catalog-description {
   font-size: 13px;
-  color: rgba(0, 0, 0, 0.72);
+  color: var(--mat-sys-on-surface-variant);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/apps/client/src/app/presentation/presentation-request/presentation-request.component.scss
+++ b/apps/client/src/app/presentation/presentation-request/presentation-request.component.scss
@@ -19,7 +19,7 @@
   display: block;
   font-weight: 500;
   margin-bottom: 12px;
-  color: rgba(0, 0, 0, 0.87);
+  color: var(--mat-sys-on-surface-variant);
 }
 
 .preview-card {
@@ -39,26 +39,26 @@
 
   strong {
     font-weight: 500;
-    color: rgba(0, 0, 0, 0.87);
+    color: var(--mat-sys-on-surface-variant);
   }
 
   span {
-    color: rgba(0, 0, 0, 0.6);
+    color: var(--mat-sys-on-surface-variant);
   }
 }
 
 .dcql-query {
   box-sizing: border-box;
   max-width: 100%;
-  background-color: #f5f5f5;
-  border: 1px solid #e0e0e0;
+  background-color: var(--mat-sys-surface-container);
+  border: 1px solid var(--mat-sys-outline-variant);
   border-radius: 4px;
   padding: 12px;
   font-size: 12px;
   overflow-x: hidden;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
-  color: rgba(0, 0, 0, 0.7);
+  color: var(--mat-sys-on-surface-variant);
   margin-top: 8px;
 }
 
@@ -66,7 +66,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  color: rgba(0, 0, 0, 0.7);
+  color: var(--mat-sys-on-surface-variant);
 
   mat-icon {
     font-size: 18px;
@@ -75,24 +75,24 @@
   }
 
   &.readiness-error {
-    color: #c62828;
+    color: var(--eudiplo-danger);
   }
 }
 
 .result-card {
-  background: linear-gradient(135deg, #e8f5e8 0%, #f0f9ff 100%);
-  border: 1px solid #4caf50;
+  background: linear-gradient(135deg, var(--mat-sys-secondary-container) 0%, #f0f9ff 100%);
+  border: 1px solid var(--eudiplo-success);
   margin-top: 24px;
 
   mat-card-header {
-    background: rgba(76, 175, 80, 0.1);
+    background: var(--eudiplo-success-soft);
     padding: 16px;
 
     mat-card-title {
-      color: #2e7d32;
+      color: var(--eudiplo-success);
 
       mat-icon {
-        color: #4caf50;
+        color: var(--eudiplo-success);
         margin-right: 8px;
       }
     }
@@ -110,7 +110,7 @@
     display: block;
     font-weight: 500;
     margin-bottom: 8px;
-    color: rgba(0, 0, 0, 0.87);
+    color: var(--mat-sys-on-surface-variant);
   }
 }
 
@@ -119,7 +119,7 @@
   align-items: center;
   gap: 8px;
   padding: 12px;
-  background-color: #f8f9fa;
+  background-color: var(--mat-sys-surface-container);
   border: 1px solid #e9ecef;
   border-radius: 4px;
 
@@ -127,7 +127,7 @@
     flex: 1;
     font-family: 'Courier New', monospace;
     font-size: 14px;
-    color: #495057;
+    color: var(--mat-sys-on-surface-variant);
     word-break: break-all;
 
     &.uri-value {
@@ -148,7 +148,7 @@
     display: block;
     font-weight: 500;
     margin-bottom: 12px;
-    color: rgba(0, 0, 0, 0.87);
+    color: var(--mat-sys-on-surface-variant);
   }
 }
 
@@ -156,8 +156,8 @@
   display: flex;
   justify-content: center;
   padding: 20px;
-  background-color: #ffffff;
-  border: 1px solid #e0e0e0;
+  background-color: var(--mat-sys-on-error);
+  border: 1px solid var(--mat-sys-outline-variant);
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 
@@ -175,22 +175,22 @@
   align-items: center;
   justify-content: center;
   padding: 40px;
-  border: 2px dashed #ccc;
+  border: 2px dashed var(--mat-sys-outline-variant);
   border-radius: 8px;
-  background-color: #fafafa;
+  background-color: var(--mat-sys-surface-container);
   text-align: center;
 
   mat-icon {
     font-size: 48px;
     width: 48px;
     height: 48px;
-    color: #ccc;
+    color: var(--mat-sys-outline-variant);
     margin-bottom: 16px;
   }
 
   p {
     margin: 0;
-    color: rgba(0, 0, 0, 0.6);
+    color: var(--mat-sys-on-surface-variant);
   }
 }
 
@@ -209,18 +209,18 @@
       font-size: 64px;
       width: 64px;
       height: 64px;
-      color: #ff9800;
+      color: var(--eudiplo-warning);
       margin-bottom: 16px;
     }
 
     h3 {
       margin: 16px 0 8px 0;
-      color: rgba(0, 0, 0, 0.87);
+      color: var(--mat-sys-on-surface-variant);
     }
 
     p {
       margin: 0 0 24px 0;
-      color: rgba(0, 0, 0, 0.6);
+      color: var(--mat-sys-on-surface-variant);
     }
   }
 }
@@ -245,13 +245,13 @@
 
   // Success snackbar styling
   .success-snackbar {
-    --mdc-snackbar-container-color: #4caf50;
+    --mdc-snackbar-container-color: var(--eudiplo-success);
     --mdc-snackbar-supporting-text-color: white;
   }
 
   // Error snackbar styling
   .error-snackbar {
-    --mdc-snackbar-container-color: #f44336;
+    --mdc-snackbar-container-color: var(--eudiplo-danger);
     --mdc-snackbar-supporting-text-color: white;
   }
 }
@@ -273,23 +273,23 @@
   min-width: 70px;
 
   &.status-active {
-    background-color: #e8f5e8;
-    color: #2e7d32;
+    background-color: var(--mat-sys-secondary-container);
+    color: var(--eudiplo-success);
   }
 
   &.status-completed {
-    background-color: #e3f2fd;
-    color: #1976d2;
+    background-color: var(--mat-sys-primary-container);
+    color: var(--eudiplo-info);
   }
 
   &.status-expired {
-    background-color: #fff3e0;
-    color: #f57c00;
+    background-color: var(--mat-sys-tertiary-container);
+    color: var(--eudiplo-warning);
   }
 
   &.status-failed {
-    background-color: #ffebee;
-    color: #d32f2f;
+    background-color: var(--mat-sys-error-container);
+    color: var(--eudiplo-danger);
   }
 }
 
@@ -298,7 +298,7 @@
   align-items: center;
   gap: 4px;
   font-size: 12px;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--mat-sys-on-surface-variant);
 
   .spinning {
     font-size: 16px;

--- a/apps/client/src/app/registrar/registrar.component.scss
+++ b/apps/client/src/app/registrar/registrar.component.scss
@@ -13,7 +13,7 @@ h1 {
 
 .loading-container {
   min-height: 200px;
-  color: rgba(0, 0, 0, 0.54);
+  color: var(--mat-sys-on-surface-variant);
 }
 
 mat-card {
@@ -49,7 +49,7 @@ mat-card {
 
 .section-help {
   margin: 0;
-  color: rgba(0, 0, 0, 0.7);
+  color: var(--mat-sys-on-surface-variant);
 }
 
 .button-spinner {
@@ -58,10 +58,10 @@ mat-card {
 }
 
 .info-card {
-  background-color: #e3f2fd;
+  background-color: var(--mat-sys-primary-container);
 
   .info-icon {
-    color: #1976d2;
+    color: var(--eudiplo-info);
     font-size: 32px;
     height: 32px;
     width: 32px;

--- a/apps/client/src/app/schema-metadata/schema-metadata-create/schema-metadata-create.component.scss
+++ b/apps/client/src/app/schema-metadata/schema-metadata-create/schema-metadata-create.component.scss
@@ -3,7 +3,7 @@ mat-card {
 }
 
 .hint-text {
-  color: #666;
+  color: var(--mat-sys-on-surface-variant);
   font-size: 14px;
   margin: 8px 0;
 

--- a/apps/client/src/app/schema-metadata/schema-metadata-list/schema-metadata-list.component.scss
+++ b/apps/client/src/app/schema-metadata/schema-metadata-list/schema-metadata-list.component.scss
@@ -8,7 +8,7 @@ table {
 
 .version-pill {
   color: inherit;
-  border: 1px solid rgba(0, 0, 0, 0.12);
+  border: 1px solid var(--mat-sys-outline-variant);
   border-radius: 999px;
   display: inline-block;
   font-size: 12px;
@@ -18,5 +18,5 @@ table {
 }
 
 .version-pill:hover {
-  background: rgba(0, 0, 0, 0.04);
+  background: var(--mat-sys-surface-container-high);
 }

--- a/apps/client/src/app/schema-metadata/schema-metadata-show/schema-metadata-show.component.scss
+++ b/apps/client/src/app/schema-metadata/schema-metadata-show/schema-metadata-show.component.scss
@@ -23,12 +23,12 @@
 }
 
 .version-pill-active {
-  background: rgba(0, 0, 0, 0.06);
+  background: var(--mat-sys-surface-container-high);
 }
 
 .label {
   font-size: 12px;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--mat-sys-on-surface-variant);
 }
 
 .value {
@@ -44,7 +44,7 @@
   font-size: 18px;
   height: 18px;
   width: 18px;
-  color: rgba(0, 0, 0, 0.54);
+  color: var(--mat-sys-on-surface-variant);
   flex-shrink: 0;
 }
 

--- a/apps/client/src/app/services/theme.service.spec.ts
+++ b/apps/client/src/app/services/theme.service.spec.ts
@@ -1,0 +1,86 @@
+import { ThemeService } from './theme.service';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('ThemeService', () => {
+  let systemThemeListener: ((event: MediaQueryListEvent) => void) | undefined;
+  let systemThemeQuery: MediaQueryList;
+
+  beforeEach(() => {
+    const storage = new Map<string, string>();
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        clear: () => storage.clear(),
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+        removeItem: (key: string) => storage.delete(key),
+      },
+    });
+    localStorage.clear();
+    document.documentElement.className = '';
+    systemThemeQuery = {
+      matches: false,
+      media: '(prefers-color-scheme: dark)',
+      onchange: null,
+      addEventListener: (_type: string, listener: EventListenerOrEventListenerObject) => {
+        systemThemeListener = listener as (event: MediaQueryListEvent) => void;
+      },
+      removeEventListener: () => {
+        systemThemeListener = undefined;
+      },
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    } as MediaQueryList;
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: () => systemThemeQuery,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses the system preference when no saved preference exists', () => {
+    systemThemeQuery = { ...systemThemeQuery, matches: true } as MediaQueryList;
+
+    const service = new ThemeService();
+
+    expect(service.isDarkMode).toBe(true);
+    expect(document.documentElement.classList.contains('dark-theme')).toBe(true);
+    service.destroy();
+  });
+
+  it('persists an explicit user preference', () => {
+    const service = new ThemeService();
+
+    service.toggle();
+
+    expect(service.isDarkMode).toBe(true);
+    expect(localStorage.getItem('eudiplo-theme')).toBe('dark');
+    service.destroy();
+  });
+
+  it('follows system changes until the user chooses a mode', () => {
+    const service = new ThemeService();
+    const changes: boolean[] = [];
+    service.themeChanges.subscribe((isDark) => changes.push(isDark));
+
+    systemThemeListener?.({ matches: true } as MediaQueryListEvent);
+
+    expect(service.isDarkMode).toBe(true);
+    expect(changes).toEqual([true]);
+    service.destroy();
+  });
+
+  it('ignores system changes after the user chooses a mode', () => {
+    const service = new ThemeService();
+    service.toggle();
+
+    systemThemeListener?.({ matches: false } as MediaQueryListEvent);
+
+    expect(service.isDarkMode).toBe(true);
+    service.destroy();
+  });
+});

--- a/apps/client/src/app/services/theme.service.ts
+++ b/apps/client/src/app/services/theme.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  private readonly storageKey = 'eudiplo-theme';
+  readonly themeChanges = new Subject<boolean>();
+  isDarkMode = false;
+  private readonly systemThemeQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  private hasUserPreference = false;
+
+  constructor() {
+    const storedTheme = localStorage.getItem(this.storageKey);
+    this.hasUserPreference = storedTheme === 'dark' || storedTheme === 'light';
+    this.isDarkMode = this.hasUserPreference
+      ? storedTheme === 'dark'
+      : this.systemThemeQuery.matches;
+    this.systemThemeQuery.addEventListener('change', this.handleSystemThemeChange);
+    this.applyTheme();
+  }
+
+  toggle(): void {
+    this.isDarkMode = !this.isDarkMode;
+    this.hasUserPreference = true;
+    localStorage.setItem(this.storageKey, this.isDarkMode ? 'dark' : 'light');
+    this.themeChanges.next(this.isDarkMode);
+    this.applyTheme();
+  }
+
+  destroy(): void {
+    this.systemThemeQuery.removeEventListener('change', this.handleSystemThemeChange);
+    this.themeChanges.complete();
+  }
+
+  private readonly handleSystemThemeChange = (event: MediaQueryListEvent): void => {
+    if (this.hasUserPreference) {
+      return;
+    }
+
+    this.isDarkMode = event.matches;
+    this.themeChanges.next(this.isDarkMode);
+    this.applyTheme();
+  };
+
+  private applyTheme(): void {
+    document.documentElement.classList.toggle('dark-theme', this.isDarkMode);
+  }
+}

--- a/apps/client/src/app/session-management/session-management-list/session-management-list.component.scss
+++ b/apps/client/src/app/session-management/session-management-list/session-management-list.component.scss
@@ -25,44 +25,44 @@
 
   .type-badge {
     &.issuance {
-      background-color: #e8f5e8;
-      color: #2e7d32;
+      background-color: var(--mat-sys-secondary-container);
+      color: var(--eudiplo-success);
     }
 
     &.presentation {
-      background-color: #e3f2fd;
-      color: #1976d2;
+      background-color: var(--mat-sys-primary-container);
+      color: var(--eudiplo-info);
     }
   }
 
   .status-badge {
-    background-color: #f5f5f5;
-    color: #666;
+    background-color: var(--mat-sys-surface-container);
+    color: var(--mat-sys-on-surface-variant);
 
     &.status-active {
-      background-color: #e8f5e8;
-      color: #2e7d32;
+      background-color: var(--mat-sys-secondary-container);
+      color: var(--eudiplo-success);
     }
 
     &.status-completed {
-      background-color: #e3f2fd;
-      color: #1976d2;
+      background-color: var(--mat-sys-primary-container);
+      color: var(--eudiplo-info);
     }
 
     &.status-expired {
-      background-color: #fff3e0;
-      color: #f57c00;
+      background-color: var(--mat-sys-tertiary-container);
+      color: var(--eudiplo-warning);
     }
 
     &.status-failed {
-      background-color: #ffebee;
-      color: #d32f2f;
+      background-color: var(--mat-sys-error-container);
+      color: var(--eudiplo-danger);
     }
   }
 
   .date-text {
     font-size: 13px;
-    color: #666;
+    color: var(--mat-sys-on-surface-variant);
   }
 }
 
@@ -89,14 +89,14 @@
 }
 
 .bulk-actions {
-  background-color: #f5f5f5;
+  background-color: var(--mat-sys-surface-container);
   padding: 8px 16px;
   border-radius: 8px;
   margin-left: 16px;
 
   .selection-info {
     font-size: 14px;
-    color: #666;
+    color: var(--mat-sys-on-surface-variant);
     margin-right: 8px;
   }
 }
@@ -118,7 +118,7 @@
   left: 0;
   bottom: 0;
   right: 0;
-  background: rgba(0, 0, 0, 0.15);
+  background: var(--eudiplo-scrim-soft);
   z-index: 1;
   display: flex;
   align-items: center;

--- a/apps/client/src/app/session-management/session-management-show/session-management-show.component.scss
+++ b/apps/client/src/app/session-management/session-management-show/session-management-show.component.scss
@@ -4,7 +4,7 @@
   align-items: center;
   gap: 4px;
   font-size: 12px;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--mat-sys-on-surface-variant);
 
   .spinning {
     font-size: 16px;
@@ -54,7 +54,7 @@
     word-break: break-all;
     font-family: monospace;
     font-size: 12px;
-    background-color: #f5f5f5;
+    background-color: var(--mat-sys-surface-container);
     padding: 4px 8px;
     border-radius: 4px;
     flex: 1;
@@ -63,7 +63,7 @@
 
 .creation-date {
   font-size: 14px;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--mat-sys-on-surface-variant);
 }
 
 .qr-section {
@@ -77,7 +77,7 @@
   display: flex;
   justify-content: center;
   padding: 20px;
-  background-color: #f9f9f9;
+  background-color: var(--mat-sys-surface-container);
   border-radius: 8px;
 
   .qr-image {
@@ -93,9 +93,9 @@
   align-items: center;
   justify-content: center;
   padding: 40px;
-  background-color: #f9f9f9;
+  background-color: var(--mat-sys-surface-container);
   border-radius: 8px;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--mat-sys-on-surface-variant);
 
   mat-icon {
     font-size: 48px;
@@ -116,9 +116,9 @@
   align-items: center;
   gap: 12px;
   padding: 16px;
-  background-color: #fff3e0;
+  background-color: var(--mat-sys-tertiary-container);
   border-radius: 8px;
-  color: #f57c00;
+  color: var(--eudiplo-warning);
 
   mat-icon {
     font-size: 20px;
@@ -139,34 +139,34 @@
 
 // Status chips
 .status-success {
-  background-color: #4caf50 !important;
+  background-color: var(--eudiplo-success) !important;
   color: white !important;
 }
 
 .status-pending {
-  background-color: #ff9800 !important;
+  background-color: var(--eudiplo-warning) !important;
   color: white !important;
 }
 
 .status-error {
-  background-color: #f44336 !important;
+  background-color: var(--eudiplo-danger) !important;
   color: white !important;
 }
 
 .status-default {
-  background-color: #9e9e9e !important;
+  background-color: var(--mat-sys-on-surface-variant) !important;
   color: white !important;
 }
 
 // Snackbar styles
 ::ng-deep {
   .success-snackbar {
-    --mdc-snackbar-container-color: #4caf50;
+    --mdc-snackbar-container-color: var(--eudiplo-success);
     --mdc-snackbar-supporting-text-color: white;
   }
 
   .error-snackbar {
-    --mdc-snackbar-container-color: #f44336;
+    --mdc-snackbar-container-color: var(--eudiplo-danger);
     --mdc-snackbar-supporting-text-color: white;
   }
 }
@@ -177,7 +177,7 @@
 
 // JSON and JWT display formatting
 .json-display {
-  background-color: #f5f5f5;
+  background-color: var(--mat-sys-surface-container);
   padding: 16px;
   border-radius: 4px;
   font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
@@ -200,16 +200,16 @@
   padding: 12px;
   border-radius: 4px;
   border-left: 4px solid #90caf9;
-  background: #fafafa;
+  background: var(--mat-sys-surface-container);
 
   &.log-error {
-    border-left-color: #ef5350;
-    background: #fff5f5;
+    border-left-color: var(--eudiplo-danger);
+    background: var(--mat-sys-error-container);
   }
 
   &.log-warn {
-    border-left-color: #ffa726;
-    background: #fffbf0;
+    border-left-color: var(--eudiplo-warning);
+    background: var(--mat-sys-tertiary-container);
   }
 }
 
@@ -229,12 +229,12 @@
 
 .log-stage {
   font-weight: 500;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--mat-sys-on-surface-variant);
 }
 
 .log-timestamp {
   margin-left: auto;
-  color: rgba(0, 0, 0, 0.45);
+  color: var(--mat-sys-on-surface-variant);
   font-size: 11px;
 }
 

--- a/apps/client/src/app/settings/connection-settings/connection-settings.component.scss
+++ b/apps/client/src/app/settings/connection-settings/connection-settings.component.scss
@@ -14,7 +14,7 @@
 
 .hint-row {
   margin-top: 8px;
-  color: #1565c0;
+  color: var(--eudiplo-info);
   font-size: 14px;
 
   mat-icon {

--- a/apps/client/src/app/status-list-management/status-list-edit/status-list-edit.component.scss
+++ b/apps/client/src/app/status-list-management/status-list-edit/status-list-edit.component.scss
@@ -9,7 +9,7 @@
 
 // Stats section
 .stats-section {
-  background: rgba(0, 0, 0, 0.02);
+  background: var(--mat-sys-surface-container-low);
   border-radius: 8px;
   padding: 16px;
 }
@@ -22,7 +22,7 @@
 
 .stat-label {
   font-size: 12px;
-  color: rgba(0, 0, 0, 0.54);
+  color: var(--mat-sys-on-surface-variant);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -37,7 +37,7 @@
 
   .usage-label {
     font-size: 12px;
-    color: rgba(0, 0, 0, 0.54);
+    color: var(--mat-sys-on-surface-variant);
     text-transform: uppercase;
     letter-spacing: 0.5px;
   }
@@ -71,22 +71,22 @@
 }
 
 .status-valid {
-  background-color: #e8f5e9 !important;
-  color: #2e7d32 !important;
+  background-color: var(--mat-sys-secondary-container) !important;
+  color: var(--eudiplo-success) !important;
 }
 
 .status-expiring {
-  background-color: #fff3e0 !important;
-  color: #bf360c !important;
+  background-color: var(--mat-sys-tertiary-container) !important;
+  color: var(--eudiplo-warning) !important;
 }
 
 .status-expired {
-  background-color: #ffebee !important;
-  color: #c62828 !important;
+  background-color: var(--mat-sys-error-container) !important;
+  color: var(--eudiplo-danger) !important;
 }
 
 .muted {
-  color: rgba(0, 0, 0, 0.54);
+  color: var(--mat-sys-on-surface-variant);
   font-style: italic;
 }
 
@@ -96,9 +96,9 @@
   align-items: flex-start;
   gap: 12px;
   padding: 12px 16px;
-  background-color: #e3f2fd;
+  background-color: var(--mat-sys-primary-container);
   border-radius: 8px;
-  color: #1565c0;
+  color: var(--eudiplo-info);
 
   mat-icon {
     flex-shrink: 0;

--- a/apps/client/src/app/status-list-management/status-list-list/status-list-list.component.scss
+++ b/apps/client/src/app/status-list-management/status-list-list/status-list-list.component.scss
@@ -14,22 +14,22 @@ table {
     font-size: 64px;
     width: 64px;
     height: 64px;
-    color: rgba(0, 0, 0, 0.26);
+    color: var(--mat-sys-on-surface-variant);
   }
 
   p {
-    color: rgba(0, 0, 0, 0.54);
+    color: var(--mat-sys-on-surface-variant);
     margin: 0;
   }
 
   .hint {
     font-size: 14px;
-    color: rgba(0, 0, 0, 0.38);
+    color: var(--mat-sys-on-surface-variant);
   }
 }
 
 .muted {
-  color: rgba(0, 0, 0, 0.54);
+  color: var(--mat-sys-on-surface-variant);
   font-style: italic;
 }
 
@@ -55,16 +55,16 @@ table {
 }
 
 .status-valid {
-  background-color: #e8f5e9 !important;
-  color: #2e7d32 !important;
+  background-color: var(--mat-sys-secondary-container) !important;
+  color: var(--eudiplo-success) !important;
 }
 
 .status-expiring {
-  background-color: #fff3e0 !important;
-  color: #bf360c !important;
+  background-color: var(--mat-sys-tertiary-container) !important;
+  color: var(--eudiplo-warning) !important;
 }
 
 .status-expired {
-  background-color: #ffebee !important;
-  color: #c62828 !important;
+  background-color: var(--mat-sys-error-container) !important;
+  color: var(--eudiplo-danger) !important;
 }

--- a/apps/client/src/app/tenants/client/client-list/client-list.component.scss
+++ b/apps/client/src/app/tenants/client/client-list/client-list.component.scss
@@ -6,7 +6,7 @@
 .status-text {
   margin-left: 8px;
   font-size: 14px;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--mat-sys-on-surface-variant);
 }
 
 .no-data {
@@ -15,7 +15,7 @@
 
   p {
     margin-bottom: 20px;
-    color: rgba(0, 0, 0, 0.6);
+    color: var(--mat-sys-on-surface-variant);
   }
 
   button {
@@ -41,12 +41,12 @@
 
   h3 {
     margin: 0;
-    color: rgba(0, 0, 0, 0.87);
+    color: var(--mat-sys-on-surface-variant);
   }
 
   p {
     margin: 8px 0;
-    color: rgba(0, 0, 0, 0.6);
+    color: var(--mat-sys-on-surface-variant);
 
     &:last-of-type {
       margin-bottom: 16px;

--- a/apps/client/src/app/tenants/client/secret-dialog/secret-dialog.component.scss
+++ b/apps/client/src/app/tenants/client/secret-dialog/secret-dialog.component.scss
@@ -1,11 +1,11 @@
 .hint {
   font-size: 13px;
-  color: #666;
+  color: var(--mat-sys-on-surface-variant);
   margin-bottom: 8px;
 }
 
 .secret-box {
-  background: #f5f5f5;
+  background: var(--mat-sys-surface-container);
   border-radius: 4px;
   padding: 12px;
   margin: 12px 0;
@@ -13,7 +13,7 @@
 
 .label {
   font-size: 12px;
-  color: #666;
+  color: var(--mat-sys-on-surface-variant);
   margin-bottom: 4px;
 }
 
@@ -24,7 +24,7 @@
 }
 
 .secret {
-  color: #d32f2f;
+  color: var(--eudiplo-danger);
 }
 
 .actions-row {

--- a/apps/client/src/app/tenants/tenant-create/tenant-create.component.scss
+++ b/apps/client/src/app/tenants/tenant-create/tenant-create.component.scss
@@ -1,21 +1,21 @@
 .initial-client-section {
   margin-top: 16px;
   padding: 16px;
-  background-color: rgba(0, 0, 0, 0.02);
+  background-color: var(--mat-sys-surface-container-low);
   border-radius: 8px;
-  border: 1px dashed rgba(0, 0, 0, 0.12);
+  border: 1px dashed var(--mat-sys-outline-variant);
 
   h3 {
     margin: 0 0 8px 0;
     font-size: 14px;
     font-weight: 500;
-    color: rgba(0, 0, 0, 0.7);
+    color: var(--mat-sys-on-surface-variant);
   }
 
   .section-hint {
     margin: 0 0 16px 0;
     font-size: 12px;
-    color: rgba(0, 0, 0, 0.54);
+    color: var(--mat-sys-on-surface-variant);
   }
 
   mat-form-field {

--- a/apps/client/src/app/trust-list/trust-list-edit/trust-list-edit.component.scss
+++ b/apps/client/src/app/trust-list/trust-list-edit/trust-list-edit.component.scss
@@ -1,9 +1,9 @@
 .info-card {
-  background-color: #f5f5f5;
+  background-color: var(--mat-sys-surface-container);
   margin: 16px 0;
 
   .info-icon {
-    color: #666;
+    color: var(--mat-sys-on-surface-variant);
   }
 
   mat-card-content {
@@ -12,12 +12,12 @@
 }
 
 .info-text {
-  color: #999;
+  color: var(--mat-sys-on-surface-variant);
   font-style: italic;
   margin: 0;
 
   a {
-    color: #1976d2;
+    color: var(--eudiplo-info);
   }
 }
 
@@ -45,13 +45,13 @@ mat-error {
     font-size: 64px;
     width: 64px;
     height: 64px;
-    color: rgba(0, 0, 0, 0.26);
+    color: var(--mat-sys-on-surface-variant);
   }
 
   p {
     margin: 0;
     font-size: 16px;
-    color: rgba(0, 0, 0, 0.54);
+    color: var(--mat-sys-on-surface-variant);
   }
 }
 
@@ -61,13 +61,13 @@ mat-error {
 
   &.internal-entity {
     .mat-expansion-panel-header {
-      background-color: rgba(25, 118, 210, 0.04);
+      background-color: var(--eudiplo-info-subtle);
     }
   }
 
   &.external-entity {
     .mat-expansion-panel-header {
-      background-color: rgba(156, 39, 176, 0.04);
+      background-color: var(--eudiplo-accent-subtle);
     }
   }
 
@@ -84,12 +84,12 @@ mat-error {
       font-weight: 500;
 
       &.internal {
-        background-color: #1976d2;
+        background-color: var(--eudiplo-info);
         color: white;
       }
 
       &.external {
-        background-color: #9c27b0;
+        background-color: var(--eudiplo-accent);
         color: white;
       }
     }
@@ -108,11 +108,11 @@ mat-error {
 .entity-info-section {
   margin-top: 16px;
   padding-top: 16px;
-  border-top: 1px solid #e0e0e0;
+  border-top: 1px solid var(--mat-sys-outline-variant);
 
   h4 {
     margin: 0 0 16px 0;
-    color: #666;
+    color: var(--mat-sys-on-surface-variant);
     font-size: 14px;
     font-weight: 500;
   }
@@ -122,7 +122,7 @@ mat-error {
 .no-entities-message {
   padding: 32px;
   text-align: center;
-  color: #999;
+  color: var(--mat-sys-on-surface-variant);
 
   mat-icon {
     font-size: 48px;

--- a/apps/client/src/app/trust-list/trust-list-show/trust-list-show.component.scss
+++ b/apps/client/src/app/trust-list/trust-list-show/trust-list-show.component.scss
@@ -21,7 +21,7 @@ h4 {
   margin: 10px 0 8px 0;
   font-size: 14px;
   font-weight: 500;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--mat-sys-on-surface-variant);
 }
 
 // Metadata grid for overview
@@ -40,14 +40,14 @@ h4 {
   .label {
     font-size: 12px;
     font-weight: 500;
-    color: rgba(0, 0, 0, 0.6);
+    color: var(--mat-sys-on-surface-variant);
     text-transform: uppercase;
     letter-spacing: 0.5px;
   }
 
   .value {
     font-size: 14px;
-    color: rgba(0, 0, 0, 0.87);
+    color: var(--mat-sys-on-surface-variant);
   }
 }
 
@@ -87,26 +87,26 @@ h4 {
   .label {
     font-size: 11px;
     font-weight: 500;
-    color: rgba(0, 0, 0, 0.54);
+    color: var(--mat-sys-on-surface-variant);
     text-transform: uppercase;
     letter-spacing: 0.3px;
   }
 
   .value {
     font-size: 13px;
-    color: rgba(0, 0, 0, 0.87);
+    color: var(--mat-sys-on-surface-variant);
 
     &.mono {
       font-family: 'Roboto Mono', monospace;
       font-size: 12px;
-      background: rgba(0, 0, 0, 0.04);
+      background: var(--mat-sys-surface-container-high);
       padding: 4px 8px;
       border-radius: 4px;
       word-break: break-all;
     }
 
     &.link {
-      color: #1976d2;
+      color: var(--eudiplo-info);
       text-decoration: none;
 
       &:hover {
@@ -117,7 +117,7 @@ h4 {
 }
 
 .pem-content {
-  background: rgba(0, 0, 0, 0.04);
+  background: var(--mat-sys-surface-container-high);
   padding: 12px;
   border-radius: 4px;
   font-family: 'Roboto Mono', monospace;
@@ -139,9 +139,9 @@ h4 {
   display: flex;
   align-items: center;
   padding: 8px 12px;
-  background: rgba(0, 0, 0, 0.02);
+  background: var(--mat-sys-surface-container-low);
   border-radius: 4px;
-  border-left: 3px solid #1976d2;
+  border-left: 3px solid var(--eudiplo-info);
 }
 
 .version-info {
@@ -153,12 +153,12 @@ h4 {
 .version-number {
   font-weight: 500;
   font-size: 14px;
-  color: #1976d2;
+  color: var(--eudiplo-info);
 }
 
 .version-date {
   font-size: 13px;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--mat-sys-on-surface-variant);
 }
 
 // Expansion panel improvements
@@ -183,11 +183,11 @@ mat-chip-set {
 .public-url-section {
   margin-top: 24px;
   padding-top: 16px;
-  border-top: 1px solid rgba(0, 0, 0, 0.08);
+  border-top: 1px solid var(--mat-sys-outline-variant);
 
   .url-description {
     font-size: 13px;
-    color: rgba(0, 0, 0, 0.6);
+    color: var(--mat-sys-on-surface-variant);
     margin: 0 0 12px 0;
   }
 
@@ -206,17 +206,17 @@ mat-chip-set {
     gap: 8px;
     margin-top: 8px;
     font-size: 12px;
-    color: rgba(0, 0, 0, 0.6);
+    color: var(--mat-sys-on-surface-variant);
 
     .hint-icon {
       font-size: 16px;
       width: 16px;
       height: 16px;
-      color: #ff9800;
+      color: var(--eudiplo-warning);
     }
 
     code {
-      background-color: rgba(0, 0, 0, 0.05);
+      background-color: var(--mat-sys-surface-container-high);
       padding: 2px 6px;
       border-radius: 4px;
       font-family: 'Roboto Mono', monospace;
@@ -231,7 +231,7 @@ mat-chip-set {
   word-break: break-all;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, 'Roboto Mono', 'Courier New', monospace;
   font-size: 0.85em;
-  color: rgba(0, 0, 0, 0.85);
+  color: var(--mat-sys-on-surface);
 }
 
 @media (max-width: 600px) {

--- a/apps/client/src/app/users/user-temporary-password-dialog/user-temporary-password-dialog.component.scss
+++ b/apps/client/src/app/users/user-temporary-password-dialog/user-temporary-password-dialog.component.scss
@@ -3,7 +3,7 @@
 }
 
 .hint {
-  color: rgba(0, 0, 0, 0.65);
+  color: var(--mat-sys-on-surface-variant);
   margin-top: 0;
 }
 
@@ -11,7 +11,7 @@
   margin: 12px 0;
   padding: 12px;
   border-radius: 8px;
-  background: #f7f7f9;
+  background: var(--mat-sys-surface-container);
   border: 1px solid #e5e7eb;
 }
 
@@ -19,7 +19,7 @@
   font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: #6b7280;
+  color: var(--mat-sys-on-surface-variant);
   margin-bottom: 4px;
 }
 
@@ -32,7 +32,7 @@
 }
 
 .secret {
-  color: #991b1b;
+  color: var(--eudiplo-danger);
   font-weight: 600;
 }
 

--- a/apps/client/src/app/utils/editor/editor.component.html
+++ b/apps/client/src/app/utils/editor/editor.component.html
@@ -2,7 +2,7 @@
   <div fxLayout="column">
     <div class="editor">
       <ngx-monaco-editor
-        [options]="editorOptions"
+        [options]="themedEditorOptions"
         [(ngModel)]="value"
         [model]="model"
         (onInit)="onEditorInit()"

--- a/apps/client/src/app/utils/editor/editor.component.ts
+++ b/apps/client/src/app/utils/editor/editor.component.ts
@@ -14,6 +14,7 @@ import {
   Component,
   forwardRef,
   OnChanges,
+  OnDestroy,
   Input,
   SimpleChanges,
   ChangeDetectionStrategy,
@@ -22,6 +23,8 @@ import { MatInputModule } from '@angular/material/input';
 import { SchemaValidation } from '../schemas';
 import schemas from '../schemas.json';
 import { FlexLayoutModule } from 'ngx-flexible-layout';
+import { Subscription } from 'rxjs';
+import { ThemeService } from '../../services/theme.service';
 
 let editorInstanceCounter = 0;
 
@@ -37,7 +40,6 @@ export function extractSchema(obj: any) {
   }
   return element;
 }
-
 @Component({
   selector: 'app-editor',
   standalone: true,
@@ -50,11 +52,12 @@ export function extractSchema(obj: any) {
     { provide: NG_VALIDATORS, useExisting: forwardRef(() => EditorComponent), multi: true },
   ],
 })
-export class EditorComponent implements ControlValueAccessor, Validator, OnChanges {
+export class EditorComponent implements ControlValueAccessor, Validator, OnChanges, OnDestroy {
   @Input() schema?: SchemaValidation;
   @Input() editorOptions: any = { language: 'json', automaticLayout: true };
   @Input() errors?: ValidationErrors | null = null;
 
+  themedEditorOptions: any;
   model?: NgxEditorModel;
 
   value = '';
@@ -66,8 +69,14 @@ export class EditorComponent implements ControlValueAccessor, Validator, OnChang
   private readonly instanceId = ++editorInstanceCounter;
   private modelVersion = 0;
   private editorInitialized = false;
+  private themeSubscription: Subscription;
 
-  constructor() {
+  constructor(private readonly themeService: ThemeService) {
+    this.themedEditorOptions = this.withTheme(this.editorOptions);
+    this.themeSubscription = this.themeService.themeChanges.subscribe(() => {
+      this.themedEditorOptions = this.withTheme(this.editorOptions);
+    });
+
     addFormats(this.ajv);
     for (const schema of schemas) {
       const key = (schema.schema as any)['$id'].split('/').pop() || '';
@@ -155,6 +164,10 @@ export class EditorComponent implements ControlValueAccessor, Validator, OnChang
   }
 
   ngOnChanges(changes: SimpleChanges): void {
+    if ('editorOptions' in changes) {
+      this.themedEditorOptions = this.withTheme(this.editorOptions);
+    }
+
     if ('editorOptions' in changes || 'schema' in changes) {
       this.rebuildModel();
     }
@@ -176,6 +189,10 @@ export class EditorComponent implements ControlValueAccessor, Validator, OnChang
     }
   }
 
+  ngOnDestroy(): void {
+    this.themeSubscription.unsubscribe();
+  }
+
   private _onChange: (v: any) => void = () => {};
   private _onTouched: () => void = () => {};
   private _validatorChange?: () => void;
@@ -190,6 +207,13 @@ export class EditorComponent implements ControlValueAccessor, Validator, OnChang
       language: this.editorOptions?.language ?? 'json',
       // URI-based schema matching is required for Monaco JSON autocomplete.
       uri,
+    };
+  }
+
+  private withTheme(options: any): any {
+    return {
+      ...options,
+      theme: this.themeService.isDarkMode ? 'vs-dark' : 'vs-light',
     };
   }
 

--- a/apps/client/src/app/webhook-endpoint/webhook-endpoint-create/webhook-endpoint-create.component.scss
+++ b/apps/client/src/app/webhook-endpoint/webhook-endpoint-create/webhook-endpoint-create.component.scss
@@ -9,7 +9,7 @@ mat-card-header {
     gap: 8px;
 
     mat-icon {
-      color: #666;
+      color: var(--mat-sys-on-surface-variant);
     }
   }
 }

--- a/apps/client/src/app/webhook-endpoint/webhook-endpoint-show/webhook-endpoint-show.component.scss
+++ b/apps/client/src/app/webhook-endpoint/webhook-endpoint-show/webhook-endpoint-show.component.scss
@@ -19,7 +19,7 @@ mat-card-header {
     gap: 8px;
 
     mat-icon {
-      color: #666;
+      color: var(--mat-sys-on-surface-variant);
     }
   }
 }

--- a/apps/client/src/styles.scss
+++ b/apps/client/src/styles.scss
@@ -1,6 +1,24 @@
 /* You can add global styles to this file, and also import other style files */
 @use '@angular/material' as mat;
 
+:root {
+  --eudiplo-info: #1976d2;
+  --eudiplo-success: #2e7d32;
+  --eudiplo-warning: #e65100;
+  --eudiplo-danger: #c62828;
+  --eudiplo-accent: #7b1fa2;
+  --eudiplo-info-soft: color-mix(in srgb, var(--eudiplo-info) 8%, transparent);
+  --eudiplo-info-subtle: color-mix(in srgb, var(--eudiplo-info) 4%, transparent);
+  --eudiplo-info-border: color-mix(in srgb, var(--eudiplo-info) 18%, transparent);
+  --eudiplo-success-soft: color-mix(in srgb, var(--eudiplo-success) 10%, transparent);
+  --eudiplo-success-subtle: color-mix(in srgb, var(--eudiplo-success) 5%, transparent);
+  --eudiplo-success-border: color-mix(in srgb, var(--eudiplo-success) 30%, transparent);
+  --eudiplo-warning-soft: color-mix(in srgb, var(--eudiplo-warning) 12%, transparent);
+  --eudiplo-warning-subtle: color-mix(in srgb, var(--eudiplo-warning) 10%, transparent);
+  --eudiplo-accent-subtle: color-mix(in srgb, var(--eudiplo-accent) 4%, transparent);
+  --eudiplo-scrim-soft: color-mix(in srgb, var(--mat-sys-scrim) 15%, transparent);
+}
+
 html {
   height: 100%;
   @include mat.theme(
@@ -14,6 +32,28 @@ html {
       density: 0,
     )
   );
+
+  &.dark-theme {
+    color-scheme: dark;
+
+    --eudiplo-info: #90caf9;
+    --eudiplo-success: #81c784;
+    --eudiplo-warning: #ffb74d;
+    --eudiplo-danger: #ef9a9a;
+    --eudiplo-accent: #ce93d8;
+
+    @include mat.theme(
+      (
+        color: (
+          primary: mat.$blue-palette,
+          tertiary: mat.$orange-palette,
+          theme-type: dark,
+        ),
+        typography: Roboto,
+        density: 0,
+      )
+    );
+  }
 }
 
 body {
@@ -21,7 +61,11 @@ body {
   padding: 0;
   height: 100%;
   font-family: Roboto, 'Helvetica Neue', sans-serif;
-  background-color: #f5f5f5; // Background for the entire app
+  background-color: var(--mat-sys-background);
+  color: var(--mat-sys-on-background);
+  transition:
+    background-color 180ms ease,
+    color 180ms ease;
 }
 
 // Ensure Angular app fills full height

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -375,7 +375,7 @@ importers:
         version: 1.5.11(@rspack/core@1.7.12)(@swc/core@1.16.1)(esbuild@0.28.2)(rolldown@1.2.0)(rollup@4.62.4)(vite@8.1.5(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.106.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(uglify-js@3.19.3))
       vitest:
         specifier: 4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(vite@8.1.5(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0))
 
   apps/cli:
     dependencies:
@@ -412,7 +412,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: 4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(vite@8.1.5(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0))
 
   apps/client:
     dependencies:
@@ -528,6 +528,9 @@ importers:
       istanbul-lib-instrument:
         specifier: ^6.0.3
         version: 6.0.3(supports-color@10.2.2)
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1(@noble/hashes@2.3.0)
       karma:
         specifier: ~6.4.4
         version: 6.4.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
@@ -545,7 +548,7 @@ importers:
         version: 8.67.0(eslint@10.9.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(vite@8.1.5(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0))
 
   apps/docs:
     dependencies:
@@ -642,7 +645,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.101.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.101.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0))
 
 packages:
 
@@ -1018,6 +1021,14 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@asamuzakjp/css-color@6.0.7':
+    resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
+    engines: {node: ^22.13.0 || >=24.0.0}
 
   '@aws-sdk/checksums@3.1000.29':
     resolution: {integrity: sha512-Dtu0gr4dnATZAPwEYbpCsG+MpLM7OAliy2gTepEFQwl1vZ6DL3QMH2FveMa3HLvPsOdhJsPRB3KtxVhph9T75A==}
@@ -1878,6 +1889,10 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@cbor-extract/cbor-extract-darwin-arm64@2.2.2':
     resolution: {integrity: sha512-ZKZ/F8US7JR92J4DMct6cLW/Y66o2K576+zjlEN/MevH70bFIsB10wkZEQPLzl2oNh2SMGy55xpJ9JoBRl5DOA==}
     cpu: [arm64]
@@ -1977,12 +1992,23 @@ packages:
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
     engines: {node: '>=18'}
 
+  '@csstools/color-helpers@6.1.1':
+    resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
+    engines: {node: '>=20.19.0'}
+
   '@csstools/css-calc@2.1.4':
     resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^3.0.5
       '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
 
   '@csstools/css-color-parser@3.1.0':
     resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
@@ -1991,15 +2017,40 @@ packages:
       '@csstools/css-parser-algorithms': ^3.0.5
       '@csstools/css-tokenizer': ^3.0.4
 
+  '@csstools/css-color-parser@4.2.1':
+    resolution: {integrity: sha512-YpAJZhaHplYQkG8ib+/Fx5Y0eF2lVWi3tIvMJA6i39TLyUNp2439cifzW8VMjhlqrBjHzK5hVGugRRm2zTKI/A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
   '@csstools/css-parser-algorithms@3.0.5':
     resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@csstools/css-tokenizer': ^3.0.4
 
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.9':
+    resolution: {integrity: sha512-iGGw4OsAYsS6pD29MdJ2bX/nJx65a04ZZiw6x+VwWlP2DdXf6f++Zmuv/OzALpdyfVhjbduIIF2cXM7HWBIe9A==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@csstools/media-query-list-parser@4.0.3':
     resolution: {integrity: sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==}
@@ -3026,6 +3077,15 @@ packages:
   '@eslint/plugin-kit@0.7.2':
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@fontsource/roboto@5.3.0':
     resolution: {integrity: sha512-BapRJOWYP+LZ21zp+wBQjfpPYKRoxc4LspJ/RLuI+HSMBD5u/X4O+ESDrSvEqDSy0rAl7GwBJ+09mdc16cVQ1Q==}
@@ -7518,6 +7578,9 @@ packages:
     resolution: {integrity: sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==}
     engines: {node: '>=22'}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
 
@@ -8234,6 +8297,10 @@ packages:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
@@ -8444,6 +8511,10 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   date-format@4.0.14:
     resolution: {integrity: sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==}
     engines: {node: '>=4.0'}
@@ -8477,6 +8548,9 @@ packages:
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -9553,6 +9627,10 @@ packages:
   hpack.js@2.1.6:
     resolution: {integrity: sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -9916,6 +9994,9 @@ packages:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
     engines: {node: '>=0.10.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -10072,6 +10153,15 @@ packages:
   js-yaml@5.3.0:
     resolution: {integrity: sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==}
     hasBin: true
+
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -10572,6 +10662,9 @@ packages:
 
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   mdurl@2.1.0:
     resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
@@ -12607,6 +12700,10 @@ packages:
     resolution: {integrity: sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==}
     engines: {node: '>=11.0.0'}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -13102,6 +13199,9 @@ packages:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
     engines: {node: '>=0.10'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   synckit@0.11.13:
     resolution: {integrity: sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -13267,6 +13367,13 @@ packages:
     resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.4.11:
+    resolution: {integrity: sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==}
+
+  tldts@7.4.11:
+    resolution: {integrity: sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==}
+    hasBin: true
+
   tmp@0.2.7:
     resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
@@ -13287,8 +13394,16 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   traverse@0.6.8:
     resolution: {integrity: sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==}
@@ -13849,6 +13964,10 @@ packages:
     resolution: {integrity: sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==}
     engines: {node: '>=0.10.0'}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   walk-up-path@4.0.0:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
@@ -13878,6 +13997,10 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
 
   webpack-bundle-analyzer@4.10.2:
     resolution: {integrity: sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw==}
@@ -13954,6 +14077,18 @@ packages:
   websocket-extensions@0.1.4:
     resolution: {integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==}
     engines: {node: '>=0.8.0'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -14086,6 +14221,13 @@ packages:
   xml-js@1.6.11:
     resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
     hasBin: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -14588,7 +14730,7 @@ snapshots:
       lmdb: 3.5.6
       postcss: 8.5.26
       rollup: 4.62.4
-      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(vite@8.1.5(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -14704,6 +14846,21 @@ snapshots:
     dependencies:
       package-manager-detector: 1.8.0
       tinyexec: 1.3.0
+
+  '@asamuzakjp/css-color@6.0.7':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
 
   '@aws-sdk/checksums@3.1000.29':
     dependencies:
@@ -15922,6 +16079,10 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@cbor-extract/cbor-extract-darwin-arm64@2.2.2':
     optional: true
 
@@ -15990,10 +16151,17 @@ snapshots:
 
   '@csstools/color-helpers@5.1.0': {}
 
+  '@csstools/color-helpers@6.1.1': {}
+
   '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
 
   '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
@@ -16002,11 +16170,28 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
 
+  '@csstools/css-color-parser@4.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.1
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
   '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
     dependencies:
       '@csstools/css-tokenizer': 3.0.4
 
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.9(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@csstools/media-query-list-parser@4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
@@ -17625,6 +17810,10 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.1
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.1(@noble/hashes@2.3.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.3.0
 
   '@fontsource/roboto@5.3.0': {}
 
@@ -21632,7 +21821,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(vite@8.1.5(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0))
 
   '@vitest/expect@4.1.11':
     dependencies:
@@ -22239,6 +22428,10 @@ snapshots:
   better-sqlite3@13.0.3:
     dependencies:
       node-addon-api: 8.9.1
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   big.js@5.2.2: {}
 
@@ -23026,6 +23219,11 @@ snapshots:
       mdn-data: 2.0.30
       source-map-js: 1.2.1
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   css-what@6.2.2: {}
 
   css-what@7.0.0: {}
@@ -23283,6 +23481,13 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
+  data-urls@7.0.0(@noble/hashes@2.3.0):
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.3.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   date-format@4.0.14: {}
 
   dateformat@4.6.3: {}
@@ -23304,6 +23509,8 @@ snapshots:
       supports-color: 10.2.2
 
   decamelize@1.2.0: {}
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -24684,6 +24891,12 @@ snapshots:
       readable-stream: 2.3.8
       wbuf: 1.7.3
 
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.3.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.3.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-escaper@2.0.2: {}
 
   html-minifier-terser@6.1.0:
@@ -25013,6 +25226,8 @@ snapshots:
     dependencies:
       isobject: 3.0.1
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   is-property@1.0.2: {}
@@ -25168,6 +25383,32 @@ snapshots:
   js-yaml@5.3.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@30.0.1(@noble/hashes@2.3.0):
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.7
+      '@asamuzakjp/dom-selector': 8.3.2
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.9(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.3.0)
+      css-tree: 3.2.1
+      data-urls: 7.0.0(@noble/hashes@2.3.0)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.3.0)
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.10.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0(@noble/hashes@2.3.0)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -25840,6 +26081,8 @@ snapshots:
   mdn-data@2.0.28: {}
 
   mdn-data@2.0.30: {}
+
+  mdn-data@2.27.1: {}
 
   mdurl@2.1.0: {}
 
@@ -28255,6 +28498,10 @@ snapshots:
 
   sax@1.6.1: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   schema-dts@1.1.5: {}
@@ -28905,6 +29152,8 @@ snapshots:
 
   symbol-observable@4.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   synckit@0.11.13:
     dependencies:
       '@pkgr/core': 0.3.6
@@ -29104,6 +29353,12 @@ snapshots:
 
   tinyrainbow@3.1.1: {}
 
+  tldts-core@7.4.11: {}
+
+  tldts@7.4.11:
+    dependencies:
+      tldts-core: 7.4.11
+
   tmp@0.2.7: {}
 
   to-regex-range@5.0.1:
@@ -29120,7 +29375,15 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.11
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   traverse@0.6.8: {}
 
@@ -29585,7 +29848,7 @@ snapshots:
       tsx: 4.23.12
       yaml: 2.9.0
 
-  vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.101.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)):
+  vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.101.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.11
       '@vitest/mocker': 4.1.11(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.101.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0))
@@ -29611,10 +29874,11 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 26.2.0
       '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
+      jsdom: 30.0.1(@noble/hashes@2.3.0)
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(vite@8.1.5(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)):
+  vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.11
       '@vitest/mocker': 4.1.11(vite@8.1.5(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0))
@@ -29640,10 +29904,15 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 26.2.0
       '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
+      jsdom: 30.0.1(@noble/hashes@2.3.0)
     transitivePeerDependencies:
       - msw
 
   void-elements@2.0.1: {}
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
 
   walk-up-path@4.0.0: {}
 
@@ -29669,6 +29938,8 @@ snapshots:
   web-worker@1.5.0: {}
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@8.0.1: {}
 
   webpack-bundle-analyzer@4.10.2:
     dependencies:
@@ -29853,6 +30124,24 @@ snapshots:
 
   websocket-extensions@0.1.4: {}
 
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1(@noble/hashes@2.3.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.3.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0(@noble/hashes@2.3.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.3.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
@@ -29967,6 +30256,10 @@ snapshots:
   xml-js@1.6.11:
     dependencies:
       sax: 1.6.1
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## 📝 Description

Adds comprehensive light and dark theme support to the Angular client. The theme toggle is available in the toolbar, follows the operating-system preference until a user override is selected, and persists explicit choices.

This also replaces hard-coded UI colors and translucent semantic colors with Angular Material theme tokens and shared semantic CSS variables, covering dashboards, forms, status panels, dialogs, and Monaco editors. User-configured credential branding colors remain data-driven.

## 🔄 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test improvements
- [x] 🏗️ Build/CI changes

## 💥 Breaking Changes (if applicable)

None.

## 🧪 Testing

- [x] Unit tests pass (focused ThemeService spec: 4/4)
- [ ] Integration tests pass
- [ ] E2E tests pass
- [x] Manual testing performed

**Test Configuration**:

- Node.js version: 26.1.0
- OS: macOS
- Test environment: Angular build, Vitest with jsdom, browser runtime check

Additional validation: client production build, Angular lint, formatting hooks, and Knip all pass.

## 📸 Screenshots (if applicable)

Not included.

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My code generates no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing relevant unit tests pass locally with my changes

## 📋 Additional Notes

The full Angular test command currently encounters unrelated pre-existing spec compilation issues involving legacy Jasmine APIs and an outdated AppComponent test expectation; the focused ThemeService tests pass independently.