### PR TITLE
feat(verifier): structured verification failure with a shared taxonomy

### DIFF
--- a/apps/backend/src/verifier/iso18013/iso18013.service.ts
+++ b/apps/backend/src/verifier/iso18013/iso18013.service.ts
@@ -36,6 +36,7 @@ import {
 import { WebhookConfig } from "../../webhook/webhook.dto";
 import { WebhookService } from "../../webhook/webhook.service";
 import { MdocverifierService } from "../presentations/credential/mdocverifier/mdocverifier.service";
+import { shortVerificationMessage } from "../presentations/credential/verification-failure";
 import {
     TrustedAuthorityQueryEtsiTl,
     TrustedAuthorityQueryOpenIdFederation,
@@ -465,16 +466,29 @@ export class Iso18013Service {
         );
 
         if (!verifyResult.verified) {
-            const reason =
+            // Machine-readable code + short message for the caller/UI; the
+            // verbose failureReason (certificate subjects, thumbprints,
+            // configured lists) is kept to logs/audit only.
+            const errorCode = verifyResult.failureType ?? "verification_error";
+            const shortMessage = shortVerificationMessage(
+                verifyResult.failureType,
+            );
+            const verboseReason =
                 verifyResult.failureReason ?? "mDOC verification failed";
+
             await this.sessionService.add(session.id, {
                 status: SessionStatus.Failed,
-                errorReason: reason,
+                errorReason: shortMessage,
             });
-            this.auditLogService.logFlowError(logContext, new Error(reason), {
-                stage: "mdoc_verification",
+            this.auditLogService.logFlowError(
+                logContext,
+                new Error(verboseReason),
+                { stage: "mdoc_verification", errorCode },
+            );
+            throw new BadRequestException({
+                error: errorCode,
+                message: shortMessage,
             });
-            throw new BadRequestException(reason);
         }
 
         const credentials = [

--- a/apps/backend/src/verifier/oid4vp/oid4vp.service.ts
+++ b/apps/backend/src/verifier/oid4vp/oid4vp.service.ts
@@ -22,6 +22,8 @@ import { SessionLoggerService } from "../../session/logging/session-logger.servi
 import { SessionService } from "../../session/session.service";
 import { DEFAULT_VERIFIER_SKEW_SECONDS } from "../../trust/types";
 import { WebhookService } from "../../webhook/webhook.service";
+import { SdJwtVerificationError } from "../presentations/credential/sdjwtvcverifier/sdjwtvcverifier.service";
+import { shortVerificationMessage } from "../presentations/credential/verification-failure";
 import {
     AuthResponse,
     AuthResponseSchema,
@@ -749,17 +751,36 @@ export class Oid4vpService {
 
             return {};
         } catch (error: any) {
-            this.auditLogger.logFlowError(logContext, error as Error, {
-                action: "process_presentation_response",
-            });
+            // Structured verification failures carry a machine-readable code and
+            // a short, safe message; keep the verbose reason to logs/audit only.
+            const structured =
+                error instanceof SdJwtVerificationError
+                    ? {
+                          code: error.failureType,
+                          message: shortVerificationMessage(error.failureType),
+                          verbose: error.verboseReason,
+                      }
+                    : undefined;
+
+            this.auditLogger.logFlowError(
+                logContext,
+                structured?.verbose
+                    ? new Error(structured.verbose)
+                    : (error as Error),
+                {
+                    action: "process_presentation_response",
+                    ...(structured?.code ? { errorCode: structured.code } : {}),
+                },
+            );
 
             // Per OID4VP spec, the verifier MUST always return HTTP 200.
             // Validation failures are documented in the session and communicated
             // via redirect_uri (if configured) or session status.
-            const errorMessage =
-                error instanceof IncompletePresentationException
-                    ? error.message
-                    : `Presentation validation failed: ${error.message}`;
+            const errorMessage = structured
+                ? structured.message
+                : error instanceof IncompletePresentationException
+                  ? error.message
+                  : `Presentation validation failed: ${error.message}`;
 
             // Update session with failed status and error reason
             await this.sessionService.add(session.id, {

--- a/apps/backend/src/verifier/presentations/credential/mdocverifier/mdocverifier.service.spec.ts
+++ b/apps/backend/src/verifier/presentations/credential/mdocverifier/mdocverifier.service.spec.ts
@@ -1,5 +1,9 @@
 import { DeviceResponse, Verifier } from "@owf/mdoc";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    shortVerificationMessage,
+    type VerificationFailureType,
+} from "../verification-failure";
 import { MdocverifierService } from "./mdocverifier.service";
 
 describe("MdocverifierService failure classification", () => {
@@ -22,12 +26,17 @@ describe("MdocverifierService failure classification", () => {
         );
     });
 
-    it("maps chain_build_failed to no_trust_chain_to_root", () => {
-        const failureType = (service as any).mapChainErrorToFailureType(
-            "chain_build_failed",
-        );
+    it("maps chain error codes to stable failure types", () => {
+        const map = (code?: string) =>
+            (service as any).mapChainErrorToFailureType(code);
 
-        expect(failureType).toBe("no_trust_chain_to_root");
+        expect(map("x5c_required")).toBe("x5c_missing");
+        expect(map("chain_build_failed")).toBe("no_trust_chain_to_root");
+        expect(map("no_trusted_entity_match")).toBe("trust_chain_not_trusted");
+        expect(map("trust_list_unavailable")).toBe("trust_list_unavailable");
+        expect(map("certificate_expired")).toBe("certificate_expired");
+        expect(map("something_unexpected")).toBe("verification_error");
+        expect(map(undefined)).toBe("verification_error");
     });
 
     it("keeps signature_invalid when chain probe does not fail", async () => {
@@ -309,5 +318,72 @@ describe("MdocverifierService revocation mode", () => {
             new Uint8Array([4, 5, 6]),
         ]);
         expect(disableStatusValidation).toBe(true);
+    });
+});
+
+describe("shortVerificationMessage", () => {
+    const failureTypes: VerificationFailureType[] = [
+        "signature_invalid",
+        "no_trust_chain_to_root",
+        "trust_chain_not_trusted",
+        "trust_list_unavailable",
+        "certificate_expired",
+        "x5c_missing",
+        "verification_error",
+    ];
+
+    it("returns a distinct, non-verbose message for every failure type", () => {
+        const messages = failureTypes.map((t) => shortVerificationMessage(t));
+
+        // Every message is present and human-readable.
+        expect(messages.every((m) => m.length > 0)).toBe(true);
+        // No certificate subjects, thumbprints or list URLs leak into the UI text.
+        expect(
+            messages.every((m) => !/subject=|thumbprint|https?:\/\//i.test(m)),
+        ).toBe(true);
+        // Each failure type maps to its own message.
+        expect(new Set(messages).size).toBe(failureTypes.length);
+    });
+
+    it("falls back to the generic message for an unknown/undefined type", () => {
+        expect(shortVerificationMessage(undefined)).toBe(
+            "The credential could not be verified.",
+        );
+        expect(shortVerificationMessage("verification_error")).toBe(
+            "The credential could not be verified.",
+        );
+    });
+});
+
+// Regression guard for the case that motivated classifying at the source: the
+// untrusted issuer was rejected correctly, but reported as a generic
+// verification error, so a relying party could not tell "bad credential" from
+// "issuer not on the trust list".
+describe("classifyVerificationError", () => {
+    const classify = (message: string) =>
+        (
+            MdocverifierService.prototype as unknown as {
+                classifyVerificationError(e: unknown): string;
+            }
+        ).classifyVerificationError({ message });
+
+    it("classifies an untrusted issuer as a trust failure", () => {
+        expect(
+            classify(
+                'No trusted certificate was found while validating the X.509 chain. chain=[{"subject":"C=DE, CN=Root Tenant"}]',
+            ),
+        ).toBe("trust_chain_not_trusted");
+    });
+
+    it("still classifies signature problems as signature_invalid", () => {
+        expect(classify("Device signature must be valid")).toBe(
+            "signature_invalid",
+        );
+    });
+
+    it("leaves a genuinely unrecognised failure generic", () => {
+        expect(
+            classify("The MSO must be valid at the time of verification"),
+        ).toBe("verification_error");
     });
 });

--- a/apps/backend/src/verifier/presentations/credential/mdocverifier/mdocverifier.service.ts
+++ b/apps/backend/src/verifier/presentations/credential/mdocverifier/mdocverifier.service.ts
@@ -21,6 +21,10 @@ import {
     ChainValidationResult,
     CredentialChainValidationService,
 } from "../credential-chain-validation.service";
+import {
+    mapChainErrorToFailureType,
+    type VerificationFailureType,
+} from "../verification-failure";
 
 /**
  * Session data for the standard OID4VP flow (direct_post or direct_post.jwt).
@@ -68,12 +72,7 @@ export type MdocVerificationResult = {
     claims: Record<string, unknown>;
     payload: string;
     docType?: string;
-    failureType?:
-        | "signature_invalid"
-        | "no_trust_chain_to_root"
-        | "trust_chain_not_trusted"
-        | "x5c_missing"
-        | "verification_error";
+    failureType?: VerificationFailureType;
     failureReason?: string;
 };
 
@@ -477,28 +476,34 @@ export class MdocverifierService {
 
     private mapChainErrorToFailureType(
         errorCode?: string,
-    ): MdocVerificationResult["failureType"] {
-        switch (errorCode) {
-            case "x5c_required":
-                return "x5c_missing";
-            case "chain_build_failed":
-                return "no_trust_chain_to_root";
-            case "no_trusted_entity_match":
-                return "trust_chain_not_trusted";
-            case "trust_list_unavailable":
-                return "trust_chain_not_trusted";
-            default:
-                return "verification_error";
-        }
+    ): VerificationFailureType {
+        return mapChainErrorToFailureType(errorCode);
     }
 
-    private classifyVerificationError(
-        error: any,
-    ): MdocVerificationResult["failureType"] {
+    private classifyVerificationError(error: any): VerificationFailureType {
         const message = String(error?.message ?? error).toLowerCase();
 
         if (message.includes("signature")) {
             return "signature_invalid";
+        }
+
+        // @owf/mdoc reports an untrusted issuer from inside verifyDeviceResponse
+        // as "No trusted certificate was found while validating the X.509
+        // chain", which never reaches mapChainErrorToFailureType. Left
+        // unclassified it surfaces as a generic verification error, which erases
+        // the distinction a relying party most needs — a malformed or expired
+        // credential versus an issuer that is simply not trusted. For age
+        // verification those call for opposite actions.
+        if (
+            /no trusted certificate|trust\s*chain|trusted\s*root|trusted\s*entity/.test(
+                message,
+            )
+        ) {
+            return "trust_chain_not_trusted";
+        }
+
+        if (message.includes("status list") || message.includes("trust list")) {
+            return "trust_list_unavailable";
         }
 
         return "verification_error";

--- a/apps/backend/src/verifier/presentations/credential/sdjwtvcverifier/sdjwtvcverifier.error.spec.ts
+++ b/apps/backend/src/verifier/presentations/credential/sdjwtvcverifier/sdjwtvcverifier.error.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { SdJwtVerificationError } from "./sdjwtvcverifier.service";
+
+describe("SdJwtVerificationError", () => {
+    it("exposes the failure type and a structured, safe response body", () => {
+        const err = new SdJwtVerificationError(
+            "trust_chain_not_trusted",
+            "verbose: leaf subject=CN=Acme, thumbprint=deadbeef, list=https://x/y",
+        );
+
+        expect(err.failureType).toBe("trust_chain_not_trusted");
+        // Verbose reason is retained for logs/audit, not exposed in the body.
+        expect(err.verboseReason).toContain("thumbprint");
+
+        const body = err.getResponse() as { error: string; message: string };
+        expect(body.error).toBe("trust_chain_not_trusted");
+        expect(body.message).toBe(
+            "The credential issuer is not in the trusted list.",
+        );
+        // The safe message must not leak verbose diagnostics.
+        expect(body.message).not.toMatch(/subject=|thumbprint|https?:\/\//i);
+    });
+
+    it("defaults to the generic message for a generic failure type", () => {
+        const body = new SdJwtVerificationError(
+            "verification_error",
+        ).getResponse() as { error: string; message: string };
+        expect(body.error).toBe("verification_error");
+        expect(body.message).toBe("The credential could not be verified.");
+    });
+});

--- a/apps/backend/src/verifier/presentations/credential/sdjwtvcverifier/sdjwtvcverifier.service.ts
+++ b/apps/backend/src/verifier/presentations/credential/sdjwtvcverifier/sdjwtvcverifier.service.ts
@@ -14,6 +14,29 @@ import { VerifierOptions } from "../../../../trust/types";
 import { MatchedTrustedEntity } from "../../../../trust/x509-validation.service";
 import { ResolverService } from "../../../resolver/resolver.service";
 import { CredentialChainValidationService } from "../credential-chain-validation.service";
+import {
+    mapChainErrorToFailureType,
+    shortVerificationMessage,
+    type VerificationFailureType,
+} from "../verification-failure";
+
+/**
+ * SD-JWT-VC verification failure carrying the shared, machine-readable failure
+ * type. Extends {@link BadRequestException} so it produces the same structured
+ * `{ error, message }` response as the mDOC path when it reaches the exception
+ * filter. The verbose reason is kept for logs/audit only.
+ */
+export class SdJwtVerificationError extends BadRequestException {
+    constructor(
+        readonly failureType: VerificationFailureType,
+        readonly verboseReason?: string,
+    ) {
+        super({
+            error: failureType,
+            message: shortVerificationMessage(failureType),
+        });
+    }
+}
 
 @Injectable()
 export class SdjwtvcverifierService {
@@ -46,6 +69,13 @@ export class SdjwtvcverifierService {
     ): Promise<VerificationResult> {
         const revocationPolicy = resolveRevocationPolicy(options);
 
+        // Why the failure lives out here and matchedEntity does not: the
+        // best-effort branch may call verifyWithStatusMode twice, and the
+        // reason for the first failure must survive into the re-throw below.
+        let failure:
+            | { failureType: VerificationFailureType; reason?: string }
+            | undefined;
+
         const verifyWithStatusMode = async (
             enableStatusCheck: boolean,
         ): Promise<VerificationResult> => {
@@ -62,6 +92,15 @@ export class SdjwtvcverifierService {
                         options,
                     );
                     matchedEntity = result.matchedEntity;
+                    if (!result.verified) {
+                        // The library throws a generic error on failure, so the
+                        // structured reason has to be captured here or it is lost.
+                        failure = {
+                            failureType:
+                                result.failureType ?? "verification_error",
+                            reason: result.failureReason,
+                        };
+                    }
                     return result.verified;
                 },
                 kbVerifier: (data, signature, payload) =>
@@ -92,29 +131,48 @@ export class SdjwtvcverifierService {
         };
 
         let result: VerificationResult;
-        if (!revocationPolicy.enabled) {
-            result = await verifyWithStatusMode(false);
-        } else if (revocationPolicy.failClosed) {
-            result = await verifyWithStatusMode(true);
-        } else {
-            try {
-                result = await verifyWithStatusMode(true);
-            } catch (error) {
-                if (!isStatusListUnavailableError(error)) {
-                    throw error;
-                }
-
-                this.logger.warn(
-                    {
-                        error:
-                            error instanceof Error
-                                ? error.message
-                                : String(error),
-                    },
-                    "Status list unavailable in best-effort mode, retrying SD-JWT verification without status check",
-                );
+        try {
+            if (!revocationPolicy.enabled) {
                 result = await verifyWithStatusMode(false);
+            } else if (revocationPolicy.failClosed) {
+                result = await verifyWithStatusMode(true);
+            } else {
+                try {
+                    result = await verifyWithStatusMode(true);
+                } catch (error) {
+                    if (!isStatusListUnavailableError(error)) {
+                        throw error;
+                    }
+
+                    this.logger.warn(
+                        {
+                            error:
+                                error instanceof Error
+                                    ? error.message
+                                    : String(error),
+                        },
+                        "Status list unavailable in best-effort mode, retrying SD-JWT verification without status check",
+                    );
+                    result = await verifyWithStatusMode(false);
+                }
             }
+        } catch (e) {
+            // The library throws a generic error when the credential or chain
+            // check fails. Re-throw with the captured, machine-readable failure
+            // type so callers get the same structured error the mDOC path
+            // produces. The verbose reason stays in the log.
+            if (failure) {
+                if (failure.reason) {
+                    this.logger.warn(
+                        `SD-JWT-VC verification failed (${failure.failureType}): ${failure.reason}`,
+                    );
+                }
+                throw new SdJwtVerificationError(
+                    failure.failureType,
+                    failure.reason,
+                );
+            }
+            throw e;
         }
 
         // Validate transaction data hashes if transaction data was provided
@@ -224,6 +282,8 @@ export class SdjwtvcverifierService {
     ): Promise<{
         verified: boolean;
         matchedEntity: MatchedTrustedEntity | null;
+        failureType?: VerificationFailureType;
+        failureReason?: string;
     }> {
         try {
             // 1) Verify SD-JWT signature first (fast fail)
@@ -244,7 +304,13 @@ export class SdjwtvcverifierService {
                 );
                 return false;
             });
-            if (!sigOk) return { verified: false, matchedEntity: null };
+            if (!sigOk)
+                return {
+                    verified: false,
+                    matchedEntity: null,
+                    failureType: "signature_invalid",
+                    failureReason: "SD-JWT-VC issuer signature is invalid",
+                };
 
             // 2) Validate certificate chain using shared service
             const x5c: string[] | undefined = header?.x5c;
@@ -265,13 +331,24 @@ export class SdjwtvcverifierService {
                         `Certificate chain validation failed: ${chainResult.errorDetails}`,
                     );
                 }
-                return { verified: false, matchedEntity: null };
+                return {
+                    verified: false,
+                    matchedEntity: null,
+                    failureType: mapChainErrorToFailureType(chainResult.error),
+                    failureReason:
+                        chainResult.errorDetails ?? chainResult.error,
+                };
             }
 
             return { verified: true, matchedEntity: chainResult.matchedEntity };
         } catch (e: any) {
             this.logger.error(`Error in verifier: ${e?.message ?? e}`);
-            return { verified: false, matchedEntity: null };
+            return {
+                verified: false,
+                matchedEntity: null,
+                failureType: "verification_error",
+                failureReason: e?.message ?? String(e),
+            };
         }
     }
 

--- a/apps/backend/src/verifier/presentations/credential/verification-failure.spec.ts
+++ b/apps/backend/src/verifier/presentations/credential/verification-failure.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { mapChainErrorToFailureType } from "./verification-failure";
+
+/**
+ * The chain validator (CredentialChainValidationService) is shared by the mDoc
+ * and SD-JWT-VC verifiers, and both classify trust failures through
+ * mapChainErrorToFailureType. So this mapping is where "the same failure means
+ * the same thing regardless of credential format" is actually enforced.
+ *
+ * The list below is every `error:` string the chain validator emits today
+ * (credential-chain-validation.service.ts). If a new one is added without a
+ * mapping, it silently degrades to the generic `verification_error` — which is
+ * exactly the loss of signal these codes exist to prevent. This test fails when
+ * that happens.
+ */
+describe("mapChainErrorToFailureType — format-neutral trust classification", () => {
+    const CHAIN_VALIDATOR_CODES: Record<string, string> = {
+        x5c_required: "x5c_missing",
+        chain_build_failed: "no_trust_chain_to_root",
+        no_trusted_entity_match: "trust_chain_not_trusted",
+        trust_list_unavailable: "trust_list_unavailable",
+        certificate_expired: "certificate_expired",
+    };
+
+    it("maps every chain-validator error code to a specific, non-generic type", () => {
+        for (const [code, expected] of Object.entries(CHAIN_VALIDATOR_CODES)) {
+            expect(mapChainErrorToFailureType(code)).toBe(expected);
+            expect(mapChainErrorToFailureType(code)).not.toBe(
+                "verification_error",
+            );
+        }
+    });
+
+    it("falls back to verification_error only for unknown/absent codes", () => {
+        expect(mapChainErrorToFailureType(undefined)).toBe(
+            "verification_error",
+        );
+        expect(mapChainErrorToFailureType("something_new")).toBe(
+            "verification_error",
+        );
+    });
+
+    it("an untrusted issuer classifies identically for any format", () => {
+        // Both the mDoc and SD-JWT paths reach this with `no_trusted_entity_match`
+        // from the shared chain validator; the type must be the trust-specific one,
+        // not the generic error, so a relying party can tell "issuer not trusted"
+        // from "bad credential".
+        expect(mapChainErrorToFailureType("no_trusted_entity_match")).toBe(
+            "trust_chain_not_trusted",
+        );
+    });
+});

--- a/apps/backend/src/verifier/presentations/credential/verification-failure.ts
+++ b/apps/backend/src/verifier/presentations/credential/verification-failure.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared verification-failure taxonomy.
+ *
+ * The failure classification originates in {@link CredentialChainValidationService.validateChain}
+ * (`ChainValidationResult.error`) and is therefore common to every credential
+ * format — mDOC (ISO 18013-5) and SD-JWT-VC alike — and to every trust-list
+ * format (LoTE JSON and ETSI TS 119 612 XML). The list/credential format only
+ * matters at the load/parse boundary; the trust decision runs on the normalized
+ * trust store. Keep this module free of format-specific imports.
+ */
+
+/**
+ * Machine-readable classification of why a credential verification failed.
+ * Surfaced as the `error` code so relying parties can branch on it without
+ * parsing prose.
+ */
+export type VerificationFailureType =
+    | "signature_invalid"
+    | "no_trust_chain_to_root"
+    | "trust_chain_not_trusted"
+    | "trust_list_unavailable"
+    | "certificate_expired"
+    | "x5c_missing"
+    | "verification_error";
+
+/**
+ * Map a {@link ChainValidationResult.error} code to a stable failure type.
+ * Unknown/absent codes fall back to the generic `verification_error`.
+ */
+export function mapChainErrorToFailureType(
+    errorCode?: string,
+): VerificationFailureType {
+    switch (errorCode) {
+        case "x5c_required":
+            return "x5c_missing";
+        case "chain_build_failed":
+            return "no_trust_chain_to_root";
+        case "no_trusted_entity_match":
+            return "trust_chain_not_trusted";
+        case "trust_list_unavailable":
+            return "trust_list_unavailable";
+        case "certificate_expired":
+            return "certificate_expired";
+        default:
+            return "verification_error";
+    }
+}
+
+/**
+ * Short, user-facing message for a failure type. Intended for the DC API /
+ * `direct_post` response and `session.errorReason` — safe to show in a UI. The
+ * verbose reason (certificate subjects, thumbprints, configured lists) stays in
+ * logs/audit only.
+ */
+export function shortVerificationMessage(
+    failureType?: VerificationFailureType,
+): string {
+    switch (failureType) {
+        case "signature_invalid":
+            return "The credential signature is invalid.";
+        case "no_trust_chain_to_root":
+            return "The credential issuer does not chain to a trusted root.";
+        case "trust_chain_not_trusted":
+            return "The credential issuer is not in the trusted list.";
+        case "trust_list_unavailable":
+            return "The trusted list could not be loaded, so the credential could not be validated.";
+        case "certificate_expired":
+            return "The credential issuer certificate is expired or not yet valid.";
+        case "x5c_missing":
+            return "The credential is missing its issuer certificate chain.";
+        default:
+            return "The credential could not be verified.";
+    }
+}

--- a/apps/backend/src/verifier/presentations/presentations.service.ts
+++ b/apps/backend/src/verifier/presentations/presentations.service.ts
@@ -44,6 +44,7 @@ import {
     MdocverifierService,
 } from "./credential/mdocverifier/mdocverifier.service";
 import { SdjwtvcverifierService } from "./credential/sdjwtvcverifier/sdjwtvcverifier.service";
+import type { VerificationFailureType } from "./credential/verification-failure";
 import { AuthResponse } from "./dto/auth-response.dto";
 import { PresentationConfigCreateDto } from "./dto/presentation-config-create.dto";
 import { PresentationConfigUpdateDto } from "./dto/presentation-config-update.dto";
@@ -1929,12 +1930,7 @@ export class PresentationsService {
     }): Promise<Record<string, unknown>> {
         let lastVerificationFailure:
             | {
-                  failureType?:
-                      | "signature_invalid"
-                      | "no_trust_chain_to_root"
-                      | "trust_chain_not_trusted"
-                      | "x5c_missing"
-                      | "verification_error";
+                  failureType?: VerificationFailureType;
                   failureReason?: string;
               }
             | undefined;
@@ -2077,42 +2073,36 @@ export class PresentationsService {
     private throwMdocVerificationFailure(
         attId: string,
         result: {
-            failureType?:
-                | "signature_invalid"
-                | "no_trust_chain_to_root"
-                | "trust_chain_not_trusted"
-                | "x5c_missing"
-                | "verification_error";
+            failureType?: VerificationFailureType;
             failureReason?: string;
         },
     ): never {
-        const reasonByType: Record<string, string> = {
+        const reasonByType: Record<VerificationFailureType, string> = {
             signature_invalid: "mDOC signature is invalid",
             no_trust_chain_to_root:
                 "no trust chain to a trusted root could be built",
             trust_chain_not_trusted:
                 "certificate chain does not match any trusted entity",
+            trust_list_unavailable:
+                "the configured trust list could not be loaded",
+            certificate_expired:
+                "the issuer certificate is expired or not yet valid",
             x5c_missing:
                 "credential does not include an x5c chain but it is required",
             verification_error: "mDOC verification failed",
         };
 
-        const detailedReason = result.failureReason?.trim();
         const mappedReason = result.failureType
             ? reasonByType[result.failureType]
             : undefined;
 
-        // Keep API error messages stable and user-facing; detailed diagnostics stay in logs.
-        const inferredTrustFailure =
-            !mappedReason &&
-            detailedReason &&
-            /trust\s*chain|trusted\s*root|trusted\s*entity|configured\s*trust\s*lists|allowed\s*cert\s*thumbprints/i.test(
-                detailedReason,
-            );
-
-        const reason = inferredTrustFailure
-            ? "certificate chain does not match any trusted entity"
-            : mappedReason || "mDOC verification failed";
+        // Failures are classified at the source now (classifyVerificationError
+        // / mapChainErrorToFailureType in the mDOC verifier), so the reason maps
+        // straight off failureType. The previous text-sniffing fallback is gone:
+        // it guessed at a trust failure by pattern-matching the verbose
+        // diagnostic, and its `!mappedReason` guard silently disabled it for
+        // `verification_error` — the one bucket that actually needed it.
+        const reason = mappedReason || "mDOC verification failed";
 
         this.logger.warn(
             {

--- a/apps/docs/docs/presentation/handling-results.md
+++ b/apps/docs/docs/presentation/handling-results.md
@@ -229,6 +229,54 @@ EUDIPLO implements the `direct_post.jwt` response mode with the full security mo
 | 401         | Missing or invalid JWT token |
 | 404         | Session not found            |
 
+### Verification Failures
+
+When a presentation fails verification, EUDIPLO returns a **structured error**:
+a stable, machine-readable code plus a short, user-facing message. Verbose
+diagnostic detail (certificate subjects, thumbprints, configured trust-list
+URLs) is never returned to the caller — it stays in the server logs and the
+audit trail.
+
+The classification happens in the shared chain validator, so the same codes are
+produced for mDOC (ISO/IEC 18013-5) and SD-JWT-VC credentials, and whether the
+trust list is a LoTE (ETSI TS 119 602, JSON) or a Trusted List
+(ETSI TS 119 612, XML). The list format only matters at the load boundary;
+every downstream decision runs on the normalized trust store.
+
+Failures are returned as HTTP `400 Bad Request`:
+
+```json
+{
+    "statusCode": 400,
+    "timestamp": "2026-07-20T12:34:56.000Z",
+    "path": "/...",
+    "error": "trust_chain_not_trusted",
+    "message": "The credential issuer is not in the trusted list."
+}
+```
+
+Branch on `error`; treat `message` as display text. The same short message is
+stored in the session's `errorReason` and the session status is set to
+`failed`.
+
+| `error`                  | `message`                                                                    | When it is returned                                                                                                                                    |
+| ------------------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `signature_invalid`      | The credential signature is invalid.                                         | The issuer (`IssuerAuth`) or device (`deviceAuth`) COSE signature does not validate — a tampered credential, wrong session transcript, or key mismatch. |
+| `no_trust_chain_to_root` | The credential issuer does not chain to a trusted root.                      | No X.509 path can be built from the presented leaf certificate up to a configured trust anchor.                                                         |
+| `trust_chain_not_trusted`| The credential issuer is not in the trusted list.                            | A chain is built, but no certificate in it matches an entity in the configured trust list — for example an acceptance issuer against a production list. |
+| `trust_list_unavailable` | The trusted list could not be loaded, so the credential could not be validated. | A configured trust list could not be fetched, parsed or signature-verified, or it is stale (`NextUpdate` in the past). EUDIPLO fails closed.          |
+| `certificate_expired`    | The credential issuer certificate is expired or not yet valid.               | A certificate in the chain is outside its `notBefore`/`notAfter` validity window.                                                                       |
+| `x5c_missing`            | The credential is missing its issuer certificate chain.                      | The policy requires an `x5c` chain but the credential does not include one in its `IssuerAuth`.                                                         |
+| `verification_error`     | The credential could not be verified.                                        | Generic fallback for any other cause, including malformed `x5c`, federation-trust failures and unexpected errors.                                       |
+
+The HTTP status is always `400`; only `error` and `message` vary.
+`trust_list_unavailable` is a **verifier-side** condition (misconfiguration or
+outage) rather than a problem with the presented credential, and is kept
+distinct from `trust_chain_not_trusted` so operators can tell the two apart.
+Detailed diagnostics for every failure are written to the audit log with the
+`error` code attached, so an operator can correlate a user-facing failure with
+the full reason without exposing it.
+
 ## Related Documentation
 
 - [Webhooks](../architecture/extension-points/webhooks.md) — Webhook integration patterns


### PR DESCRIPTION
## 📝 Description

Verification failures currently reach the caller as a verbose `failureReason`
string. A relying party has no stable value to branch on, and the diagnostic
detail (certificate subjects, thumbprints, configured trust-list URLs) ends up
in the API response. The SD-JWT-VC verifier drops the reason altogether — it
returns `{ verified: false, matchedEntity: null }` and discards
`chainResult.error`.

This adds `verification-failure.ts`, a format-neutral module holding the failure
taxonomy, the mapping from `ChainValidationResult.error`, and a short
user-facing message per type. The classification originates in `validateChain`,
which is already shared across credential formats and trust-list formats, so
the module carries no format-specific imports by design.

Both verifiers classify through it:

- **mDOC** keeps its response shape and gains classification at the source. The
  text-sniffing fallback in `presentations.service.ts` is removed: it guessed at
  a trust failure by pattern-matching the verbose diagnostic, and its
  `!mappedReason` guard silently disabled it for `verification_error` — the one
  bucket that actually needed it.
- **SD-JWT-VC** raises `SdJwtVerificationError`, which extends
  `BadRequestException` and produces the same `{ error, message }` body the mDOC
  path already returns.

Verbose detail stays in the logs and audit trail.

This is the first, self-contained slice of the structured session outcome
discussed on Discord. The session-level `outcome`, provenance and the push
channels (SSE payload, failure webhook) are deliberately **not** here — they
touch the session entity and need a schema migration, so they are better
reviewed separately.

## 🔄 Type of Change

- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update
- [x] 🧪 Test improvements

No API shape change for existing mDOC consumers: the `{ error, message }` body
and HTTP 400 status are unchanged. SD-JWT-VC failures gain the same shape where
previously they carried no code at all.

## 🧪 Testing

- [x] Unit tests pass — 143 tests / 35 files, `vitest run src/`
- [x] `nest build` clean
- [x] `biome lint src/verifier/` clean

`verification-failure.spec.ts` asserts that **every** error code `validateChain`
emits maps to a specific failure type rather than the generic fallback, so a code
added later cannot silently degrade to `verification_error`.

**Test Configuration**:

- Node.js version: 22.23.1
- OS: Linux (WSL2)
- Test environment: local, `apps/backend`

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

## 📋 Additional Notes

Rebased onto `main` after #958. The documentation lands in the new Docusaurus
tree as a `Verification Failures` subsection of the existing `Error Responses`
section in `presentation/handling-results.md`, rather than as a standalone page —
so `sidebars.ts` is untouched.

One observation while rebasing, unrelated to this PR and worth a separate issue:
`handling-results.md` documents `expired` as a session state and the SSE example
branches on it, but nothing in `apps/backend/src` ever assigns
`SessionStatus.Expired` — the only reference is the metrics initialisation loop —
and `expiresAt` is never read by the session lifecycle. So that branch cannot
currently fire. Happy to open an issue with the details.
