### PR TITLE
fix(docs): fall back to the Algolia placeholders on an empty secret

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -126,9 +126,9 @@ const config: Config = {
   themeConfig: {
     image: 'img/eudiplo.png',
     algolia: {
-      appId: process.env.ALGOLIA_APP_ID ?? 'YOUR_APP_ID',
-      apiKey: process.env.ALGOLIA_SEARCH_API_KEY ?? 'YOUR_SEARCH_API_KEY',
-      indexName: process.env.ALGOLIA_INDEX_NAME ?? 'eudiplo',
+      appId: process.env.ALGOLIA_APP_ID || 'YOUR_APP_ID',
+      apiKey: process.env.ALGOLIA_SEARCH_API_KEY || 'YOUR_SEARCH_API_KEY',
+      indexName: process.env.ALGOLIA_INDEX_NAME || 'eudiplo',
       contextualSearch: true,
       searchParameters: {},
       insights: false,


### PR DESCRIPTION
## 📝 Description

`Build Documentation` fails on **every pull request opened from a fork**:

```
"algolia.appId" is not allowed to be empty
```

`ci-and-release.yml` passes the credentials through `env:` from repository secrets:

```yaml
env:
  ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
```

GitHub does not expose repository secrets to pull requests from forks, so the variable arrives as an **empty string**, not as undefined. `docusaurus.config.ts` guards with `??`, which only falls back on `null`/`undefined` — an empty string passes straight through, and Docusaurus rejects it during config validation.

Switching to `||` treats the empty string as absent as well. Behaviour is unchanged when the secrets are present, and unchanged when they are genuinely undefined; only the empty-string case moves from a hard failure to the placeholder the fallback already intended to supply.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🏗️ Build/CI changes

## 🧪 Testing

Reproduced and verified locally against `apps/docs`:

| Config | Variables | Result |
|---|---|---|
| `??` | empty strings | ✗ reproduces the CI failure exactly |
| `??` | unset | ✓ builds |
| `||` | empty strings | ✓ builds |

- [x] Manual testing performed

**Test Configuration**:

- Node.js version: 22.23.1
- OS: Linux (WSL2)
- Test environment: local, `apps/docs`, `pnpm run build`

## 📋 Additional Notes

Found while opening #970 from a fork — that PR is otherwise green (18 checks) with this the only red one. Any external contributor hits it today.

The same three variables are read in two workflow jobs (`Build documentation` and `Build generated docs content`), so both are covered by the single config change.