### PR TITLE
feat(session): persist a structured verification outcome

### DIFF
--- a/apps/backend/src/database/migrations/1779000000000-AddOutcomeToSession.ts
+++ b/apps/backend/src/database/migrations/1779000000000-AddOutcomeToSession.ts
@@ -1,0 +1,57 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+/**
+ * Add the `failureCode` and `outcome` columns to `session`.
+ *
+ * `failureCode` holds the machine-readable verification failure code when a
+ * session fails; `outcome` holds the structured verification result (success or
+ * failure, provenance and per-credential diagnostics). Both nullable and
+ * additive to the existing `status` / `errorReason`.
+ */
+export class AddOutcomeToSession1779000000000 implements MigrationInterface {
+    name = "AddOutcomeToSession1779000000000";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable("session");
+        if (!table) {
+            console.log("[Migration] session table not found — skipping.");
+            return;
+        }
+
+        if (!table.columns.some((c) => c.name === "failureCode")) {
+            await queryRunner.addColumn(
+                "session",
+                new TableColumn({
+                    name: "failureCode",
+                    type: "varchar",
+                    isNullable: true,
+                }),
+            );
+            console.log("[Migration] Added failureCode column to session.");
+        }
+
+        if (!table.columns.some((c) => c.name === "outcome")) {
+            await queryRunner.addColumn(
+                "session",
+                new TableColumn({
+                    name: "outcome",
+                    type: "json",
+                    isNullable: true,
+                }),
+            );
+            console.log("[Migration] Added outcome column to session.");
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable("session");
+        if (!table) return;
+
+        if (table.columns.some((c) => c.name === "outcome")) {
+            await queryRunner.dropColumn("session", "outcome");
+        }
+        if (table.columns.some((c) => c.name === "failureCode")) {
+            await queryRunner.dropColumn("session", "failureCode");
+        }
+    }
+}

--- a/apps/backend/src/database/migrations/index.ts
+++ b/apps/backend/src/database/migrations/index.ts
@@ -44,3 +44,4 @@ export { AddNotificationEndpointEnabledToIssuanceConfig1775000000000 } from "./1
 export { AddStatusListVersionAndUniqueConstraint1776000000000 } from "./1776000000000-AddStatusListVersionAndUniqueConstraint";
 export { AddConfigResourceMetadata1777000000000 } from "./1777000000000-AddConfigResourceMetadata";
 export { AddMissingSessionColumns1778000000000 } from "./1778000000000-AddMissingSessionColumns";
+export { AddOutcomeToSession1779000000000 } from "./1779000000000-AddOutcomeToSession";

--- a/apps/backend/src/session/entities/session-outcome.ts
+++ b/apps/backend/src/session/entities/session-outcome.ts
@@ -1,0 +1,56 @@
+/**
+ * Structured, format-agnostic result of a presentation verification, persisted
+ * on the session and surfaced to callers. Covers both success and failure,
+ * positive provenance and diagnostics, at per-credential granularity.
+ *
+ * Machine-readable `error` / `code` fields are stable; consumers branch on them.
+ * `message` fields are short and safe for display. Verbose diagnostics
+ * (certificate subjects, full chains, configured-list URLs) never appear here —
+ * they stay in the session-log/audit channel.
+ */
+
+/** Trust provenance for a successfully verified credential. */
+export interface VerificationProvenance {
+    /** Matched trusted entity id, or the issuance certificate subject. */
+    matchedIssuer?: string;
+    /** Thumbprint of the matched issuance certificate. */
+    issuanceThumbprint?: string;
+    /** How the chain matched a trusted entity (`ca` / `leaf-pinned` / …). */
+    matchMode?: string;
+    /** Thumbprint of the entity's revocation certificate, if any. */
+    revocationThumbprint?: string;
+}
+
+/** A non-fatal condition observed during verification. */
+interface SessionOutcomeWarning {
+    code: string;
+    message: string;
+}
+
+/** Per-credential verification outcome. */
+interface SessionOutcomeCredential {
+    /** Requested credential id (DCQL), when known. */
+    id?: string;
+    /** Credential format, e.g. `mso_mdoc` or `dc+sd-jwt`. */
+    format?: string;
+    /** mDOC docType or SD-JWT-VC vct, when known. */
+    docType?: string;
+    verified: boolean;
+    /** Machine-readable failure code (on failure). */
+    error?: string;
+    /** Short, safe message (on failure). */
+    message?: string;
+    /** Trust provenance (on success). */
+    trust?: VerificationProvenance;
+    warnings?: SessionOutcomeWarning[];
+}
+
+/** Overall verification outcome for a session. */
+export interface SessionOutcome {
+    result: "success" | "failed";
+    /** Top-level failure code (on failure). */
+    error?: string;
+    /** Top-level short, safe message (on failure). */
+    message?: string;
+    credentials?: SessionOutcomeCredential[];
+}

--- a/apps/backend/src/session/entities/session.entity.ts
+++ b/apps/backend/src/session/entities/session.entity.ts
@@ -19,6 +19,7 @@ import { OfferRequestDto } from "../../issuer/issuance/oid4vci/dto/offer-request
 import { EncryptedJsonTransformer } from "../../platform/data-encryption";
 import { TransactionData } from "../../verifier/presentations/entities/presentation-config.entity";
 import { WebhookConfig } from "../../webhook/webhook.dto";
+import { SessionOutcome } from "./session-outcome";
 
 export enum SessionStatus {
     Active = "active",
@@ -303,6 +304,22 @@ export class Session {
      */
     @Column("text", { nullable: true })
     errorReason?: string;
+
+    /**
+     * Machine-readable failure code when status is 'failed' (e.g.
+     * `trust_chain_not_trusted`). Stable across credential and trust-list
+     * formats; consumers branch on this rather than parsing {@link errorReason}.
+     */
+    @Column("varchar", { nullable: true })
+    failureCode?: string;
+
+    /**
+     * Structured verification outcome (success or failure, provenance and
+     * diagnostics, per credential). Additive to {@link status} /
+     * {@link errorReason}; verbose detail stays in the session log only.
+     */
+    @Column("json", { nullable: true })
+    outcome?: SessionOutcome | null;
 
     /**
      * Number of failed tx_code (transaction code) validation attempts.

--- a/apps/backend/src/verifier/iso18013/iso18013.service.ts
+++ b/apps/backend/src/verifier/iso18013/iso18013.service.ts
@@ -479,6 +479,22 @@ export class Iso18013Service {
             await this.sessionService.add(session.id, {
                 status: SessionStatus.Failed,
                 errorReason: shortMessage,
+                failureCode: errorCode,
+                outcome: {
+                    result: "failed",
+                    error: errorCode,
+                    message: shortMessage,
+                    credentials: [
+                        {
+                            id: mdocCred.id,
+                            format: "mso_mdoc",
+                            docType: verifyResult.docType,
+                            verified: false,
+                            error: errorCode,
+                            message: shortMessage,
+                        },
+                    ],
+                },
             });
             this.auditLogService.logFlowError(
                 logContext,
@@ -508,6 +524,18 @@ export class Iso18013Service {
             responseCode,
             consumed: true,
             consumedAt: new Date(),
+            outcome: {
+                result: "success",
+                credentials: [
+                    {
+                        id: mdocCred.id,
+                        format: "mso_mdoc",
+                        docType: verifyResult.docType,
+                        verified: true,
+                        trust: verifyResult.provenance,
+                    },
+                ],
+            },
         });
 
         const webhook =

--- a/apps/backend/src/verifier/oid4vp/oid4vp.service.ts
+++ b/apps/backend/src/verifier/oid4vp/oid4vp.service.ts
@@ -690,6 +690,16 @@ export class Oid4vpService {
                 responseCode,
                 consumed: true,
                 consumedAt: new Date(),
+                // Per-credential provenance for the OID4VP path is threaded in a
+                // follow-up (see finding 2026-07-21-structured-session-outcome,
+                // Phase 2); record the success result for now.
+                outcome: {
+                    result: "success",
+                    credentials: (credentials ?? []).map((c: any) => ({
+                        id: typeof c?.id === "string" ? c.id : undefined,
+                        verified: true,
+                    })),
+                },
             });
             // if there a a webhook passed in the session, use it
             if (webhook) {
@@ -786,6 +796,21 @@ export class Oid4vpService {
             await this.sessionService.add(session.id, {
                 status: SessionStatus.Failed,
                 errorReason: errorMessage,
+                ...(structured?.code
+                    ? {
+                          failureCode: structured.code,
+                          outcome: {
+                              result: "failed" as const,
+                              error: structured.code,
+                              message: errorMessage,
+                          },
+                      }
+                    : {
+                          outcome: {
+                              result: "failed" as const,
+                              message: errorMessage,
+                          },
+                      }),
             });
 
             // If redirect_uri is configured, return it with error parameter,

--- a/apps/backend/src/verifier/presentations/credential/mdocverifier/mdocverifier.service.ts
+++ b/apps/backend/src/verifier/presentations/credential/mdocverifier/mdocverifier.service.ts
@@ -11,6 +11,7 @@ import {
 import * as x509 from "@peculiar/x509";
 import { Span } from "nestjs-otel";
 import { PinoLogger } from "nestjs-pino";
+import { VerificationProvenance } from "../../../../session/entities/session-outcome";
 import {
     isStatusListUnavailableError,
     resolveRevocationPolicy,
@@ -25,6 +26,7 @@ import {
     mapChainErrorToFailureType,
     type VerificationFailureType,
 } from "../verification-failure";
+import { toProvenance } from "../verification-provenance";
 
 /**
  * Session data for the standard OID4VP flow (direct_post or direct_post.jwt).
@@ -74,6 +76,8 @@ export type MdocVerificationResult = {
     docType?: string;
     failureType?: VerificationFailureType;
     failureReason?: string;
+    /** Trust provenance for a successful verification. */
+    provenance?: VerificationProvenance;
 };
 
 /**
@@ -346,6 +350,7 @@ export class MdocverifierService {
                 claims,
                 payload: vp,
                 docType,
+                provenance: toProvenance(chainResult.matchedEntity),
             };
         } catch (error: any) {
             return this.handleVerificationError(vp, error, options);

--- a/apps/backend/src/verifier/presentations/credential/verification-provenance.spec.ts
+++ b/apps/backend/src/verifier/presentations/credential/verification-provenance.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { MatchedTrustedEntity } from "../../../trust/x509-validation.service";
+import { toProvenance } from "./verification-provenance";
+
+describe("toProvenance", () => {
+    it("returns undefined when no entity matched", () => {
+        expect(toProvenance(null)).toBeUndefined();
+    });
+
+    it("prefers the entity id and exposes safe provenance fields", () => {
+        const matched = {
+            entity: { entityId: "did:example:issuer", services: [] },
+            issuanceCert: { subject: "CN=Issuer" },
+            issuanceThumbprint: "aabbcc",
+            issuanceIsCa: true,
+            matchMode: "ca",
+            revocationThumbprint: "ddeeff",
+        } as unknown as MatchedTrustedEntity;
+
+        expect(toProvenance(matched)).toEqual({
+            matchedIssuer: "did:example:issuer",
+            issuanceThumbprint: "aabbcc",
+            matchMode: "ca",
+            revocationThumbprint: "ddeeff",
+        });
+    });
+
+    it("falls back to the certificate subject when no entity id is present", () => {
+        const matched = {
+            entity: { services: [] },
+            issuanceCert: { subject: "CN=Issuer" },
+            issuanceThumbprint: "aabbcc",
+            issuanceIsCa: false,
+            matchMode: "leaf-pinned",
+        } as unknown as MatchedTrustedEntity;
+
+        expect(toProvenance(matched)?.matchedIssuer).toBe("CN=Issuer");
+        expect(toProvenance(matched)?.revocationThumbprint).toBeUndefined();
+    });
+});

--- a/apps/backend/src/verifier/presentations/credential/verification-provenance.ts
+++ b/apps/backend/src/verifier/presentations/credential/verification-provenance.ts
@@ -1,0 +1,21 @@
+import { VerificationProvenance } from "../../../session/entities/session-outcome";
+import { MatchedTrustedEntity } from "../../../trust/x509-validation.service";
+
+/**
+ * Map a matched trusted entity to the safe, serialisable provenance surfaced on
+ * a successful verification outcome. Returns `undefined` when no entity matched
+ * (e.g. trust validation was skipped because no trust list is configured).
+ */
+export function toProvenance(
+    matched: MatchedTrustedEntity | null,
+): VerificationProvenance | undefined {
+    if (!matched) {
+        return undefined;
+    }
+    return {
+        matchedIssuer: matched.entity.entityId ?? matched.issuanceCert.subject,
+        issuanceThumbprint: matched.issuanceThumbprint,
+        matchMode: matched.matchMode,
+        revocationThumbprint: matched.revocationThumbprint,
+    };
+}


### PR DESCRIPTION
## 📝 Description

> **Rebased onto `main` now that #970 has merged.** This branch was stacked on
> it (the outcome populates its failure codes from that shared taxonomy); the
> two duplicated commits are gone and the diff is this PR's single commit.

A verification result is reported today as `status` plus a free-text
`errorReason`. A relying party reading a session back cannot tell which
credential failed, why in machine-readable terms, or — on success — which
trusted entity actually matched. `validateChain` already computes that
provenance and it is discarded before it reaches the session.

This adds a nullable `outcome` JSON column holding a normalised result:

```jsonc
{
  "result": "failed",
  "error": "trust_chain_not_trusted",
  "message": "The credential issuer is not in the trusted list.",
  "credentials": [
    { "id": "av", "format": "mso_mdoc", "verified": false,
      "error": "trust_chain_not_trusted" }
  ]
}
```

and on success the trust provenance that is currently thrown away:

```jsonc
{
  "result": "success",
  "credentials": [
    { "id": "av", "verified": true,
      "trust": { "matchedIssuer": "…", "issuanceThumbprint": "…",
                 "matchMode": "ca" } }
  ]
}
```

A `failureCode` scalar sits alongside it so failures can be filtered without
opening the JSON.

Both verifier flows populate it: the ISO 18013-7 path on success and failure,
the OID4VP path on failure. Verbose diagnostics stay in the logs and audit
trail — `outcome` carries the stable code, a short safe message and the
matched-entity identifiers, never certificate dumps or configured-list URLs.

## 🔄 Type of Change

- [x] 🚀 New feature (non-breaking change which adds functionality)

**Purely additive.** `errorReason`, `status` and the existing `{ error, message }`
HTTP shape are untouched; both new columns are nullable and existing rows are
unaffected. Nothing that reads sessions today changes behaviour.

## 💥 Breaking Changes

None. Listing the checklist items that apply:

- **API changes**: none removed or renamed; `outcome` and `failureCode` are new
  optional fields.
- **Database**: migration included — `1779000000000-AddOutcomeToSession`. It is
  idempotent (guards on `table.columns.some(...)` before adding) and numbered
  above upstream's highest, `1778000000000`, so it does not clash.
- SDK/OpenAPI regeneration will pick up the new optional fields.

## 🧪 Testing

- [x] Unit tests pass — 146 tests / 36 files, `vitest run src/`
- [x] `nest build` clean
- [x] `biome lint src/` clean

`verification-provenance.spec.ts` covers the mapping from the chain validator's
matched entity to the provenance block.

**Test Configuration**:

- Node.js version: 22.23.1
- OS: Linux (WSL2)
- Test environment: local, `apps/backend`

## 📋 Additional Notes

**Deliberately not in this PR:** the non-fatal `warnings[]` channel and the push
side — the SSE payload and the failure-webhook contract. Those are the part you
asked to have properly defined (configurable events, retry options), and #972
(`SessionStatus.Expired` documented but never assigned) is an input to that
design, so they deserve their own thread rather than riding along here. This PR
is only the persistence and the read path, which is useful on its own and
uncontroversial.

**Unrelated observation while choosing the migration number:** upstream already
has two migration classes sharing `1774000000000` —
`AddReaderAuthToPresentationConfig` and `AddRootExternalKeyIdToKeyChain`. TypeORM
keys on class name plus timestamp so both apply correctly; it only makes the
ordering ambiguous. Not touched here, just flagging it.

