### PR TITLE
Fix presentation registration certificate schema fields

### DIFF
--- a/apps/backend/src/verifier/presentations/presentations.service.ts
+++ b/apps/backend/src/verifier/presentations/presentations.service.ts
@@ -48,6 +48,7 @@ import type { VerificationFailureType } from "./credential/verification-failure"
 import { AuthResponse } from "./dto/auth-response.dto";
 import { PresentationConfigCreateDto } from "./dto/presentation-config-create.dto";
 import { PresentationConfigUpdateDto } from "./dto/presentation-config-update.dto";
+import type { RegistrationCertificateRequest } from "./dto/vp-request.dto";
 import {
     ClaimsQuery,
     CredentialQueryValue,
@@ -62,6 +63,27 @@ import { IncompletePresentationException } from "./exceptions/incomplete-present
 import { MetadataFetchService } from "./metadata-fetch.service";
 
 type CredentialType = "dc+sd-jwt" | "mso_mdoc";
+
+type RegistrationCertificateFormFields = {
+    registrationCertImportJwt?: string | null;
+    registrationCertImportId?: string | null;
+    registrationCertBodyPrivacyPolicy?: string | null;
+    registrationCertBodySupportUri?: string | null;
+    registrationCertBodyIntermediary?: string | null;
+    registrationCertBodyPurpose?: Array<{
+        lang?: string | null;
+        content?: string | null;
+    }> | null;
+};
+
+const registrationCertificateFormFieldKeys = [
+    "registrationCertImportJwt",
+    "registrationCertImportId",
+    "registrationCertBodyPrivacyPolicy",
+    "registrationCertBodySupportUri",
+    "registrationCertBodyIntermediary",
+    "registrationCertBodyPurpose",
+] as const;
 
 type ResolvedSchemaMetadataPayload = {
     id: string;
@@ -445,8 +467,10 @@ export class PresentationsService {
         actorToken?: TokenPayload,
         req?: Request,
     ) {
+        const normalizedRequest =
+            this.normalizeRegistrationCertFormFields(vprequest);
         const merged = {
-            ...vprequest,
+            ...normalizedRequest,
             tenantId,
         } as PresentationConfig;
 
@@ -491,12 +515,14 @@ export class PresentationsService {
     ) {
         // Verify the config exists
         const existing = await this.getPresentationConfig(id, tenantId);
+        const normalizedRequest =
+            this.normalizeRegistrationCertFormFields(vprequest);
 
         // Merge existing with updates - client must explicitly set fields to null to clear them
         // Omitted fields keep their existing values
         const merged: PresentationConfig = {
             ...existing,
-            ...vprequest,
+            ...normalizedRequest,
             id,
             tenantId,
         } as PresentationConfig;
@@ -504,8 +530,8 @@ export class PresentationsService {
         // Return quickly; resolve registration-certificate cache asynchronously.
         const cacheRelevantChanged =
             Object.prototype.hasOwnProperty.call(
-                vprequest,
-                "registrationCert",
+                normalizedRequest,
+                "registration_cert",
             ) || Object.prototype.hasOwnProperty.call(vprequest, "dcql_query");
 
         if (!merged.registration_cert) {
@@ -537,6 +563,87 @@ export class PresentationsService {
         }
 
         return saved;
+    }
+
+    private normalizeRegistrationCertFormFields<
+        T extends PresentationConfigCreateDto | PresentationConfigUpdateDto,
+    >(vprequest: T): T {
+        const normalized = { ...vprequest } as T &
+            RegistrationCertificateFormFields & {
+                registration_cert?: RegistrationCertificateRequest | null;
+            };
+
+        if (
+            !Object.prototype.hasOwnProperty.call(
+                normalized,
+                "registration_cert",
+            )
+        ) {
+            const registrationCert =
+                this.buildRegistrationCertFromFormFields(normalized);
+            if (registrationCert !== undefined) {
+                normalized.registration_cert = registrationCert;
+            }
+        }
+
+        for (const key of registrationCertificateFormFieldKeys) {
+            delete normalized[key];
+        }
+
+        return normalized;
+    }
+
+    private buildRegistrationCertFromFormFields(
+        fields: RegistrationCertificateFormFields,
+    ): RegistrationCertificateRequest | null | undefined {
+        const jwt = this.trimOptionalString(fields.registrationCertImportJwt);
+        if (jwt) {
+            return { jwt };
+        }
+
+        const id = this.trimOptionalString(fields.registrationCertImportId);
+        if (id) {
+            return { id };
+        }
+
+        const purpose = (fields.registrationCertBodyPurpose ?? [])
+            .map((entry) => ({
+                lang: this.trimOptionalString(entry.lang),
+                content: this.trimOptionalString(entry.content),
+            }))
+            .filter((entry): entry is { lang: string; content: string } =>
+                Boolean(entry.lang && entry.content),
+            );
+
+        const body: NonNullable<RegistrationCertificateRequest["body"]> = {};
+        const privacyPolicy = this.trimOptionalString(
+            fields.registrationCertBodyPrivacyPolicy,
+        );
+        const supportUri = this.trimOptionalString(
+            fields.registrationCertBodySupportUri,
+        );
+        const intermediary = this.trimOptionalString(
+            fields.registrationCertBodyIntermediary,
+        );
+
+        if (privacyPolicy) {
+            body.privacy_policy = privacyPolicy;
+        }
+        if (supportUri) {
+            body.support_uri = supportUri;
+        }
+        if (intermediary) {
+            body.intermediary = intermediary;
+        }
+        if (purpose.length > 0) {
+            body.purpose = purpose;
+        }
+
+        return Object.keys(body).length > 0 ? { body } : undefined;
+    }
+
+    private trimOptionalString(value: string | null | undefined): string {
+        return typeof value === "string" ? value.trim() : "";
     }
 
     /**

--- a/apps/backend/src/verifier/presentations/schemas/presentation-config.schema.spec.ts
+++ b/apps/backend/src/verifier/presentations/schemas/presentation-config.schema.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { PresentationConfigCreateSchema } from "./presentation-config.schema";
+
+const basePresentationConfig = {
+    id: "age-over-16",
+    description: "Age over 16",
+    dcql_query: {
+        credentials: [
+            {
+                id: "age_credential",
+                format: "dc+sd-jwt",
+                meta: {
+                    vct_values: ["https://example.com/age"],
+                },
+            },
+        ],
+    },
+};
+
+describe("PresentationConfigCreateSchema", () => {
+    it("accepts registration certificate fields submitted by the management UI", () => {
+        const result = PresentationConfigCreateSchema.safeParse({
+            ...basePresentationConfig,
+            registrationCertImportJwt: "",
+            registrationCertImportId: "cert-1",
+            registrationCertBodyPrivacyPolicy: "https://example.com/privacy",
+            registrationCertBodySupportUri: "https://example.com/support",
+            registrationCertBodyIntermediary: "Example Verifier",
+            registrationCertBodyPurpose: [
+                {
+                    lang: "en-US",
+                    content: "Verify age eligibility",
+                },
+            ],
+        });
+
+        expect(result.success).toBe(true);
+    });
+
+    it("continues rejecting unrelated fields", () => {
+        const result = PresentationConfigCreateSchema.safeParse({
+            ...basePresentationConfig,
+            unknownField: true,
+        });
+
+        expect(result.success).toBe(false);
+    });
+});

--- a/apps/backend/src/verifier/presentations/schemas/presentation-config.schema.ts
+++ b/apps/backend/src/verifier/presentations/schemas/presentation-config.schema.ts
@@ -273,6 +273,14 @@ const PresentationAttachmentSchema = z
     .describe("Additional presentation attachment.")
     .strict();
 
+const RegistrationCertificateFormPurposeSchema = z
+    .object({
+        lang: z.string().optional(),
+        content: z.string().optional(),
+    })
+    .describe("Registration certificate purpose entry from the management UI.")
+    .strict();
+
 export const PresentationConfigCreateSchema = z
     .object({
         id: z
@@ -311,6 +319,36 @@ export const PresentationConfigCreateSchema = z
         registration_cert: RegistrationCertificateRequestSchema.nullable()
             .optional()
             .describe("Optional registration certificate request settings."),
+        registrationCertImportJwt: z
+            .string()
+            .nullable()
+            .optional()
+            .describe("Optional imported registration certificate JWT."),
+        registrationCertImportId: z
+            .string()
+            .nullable()
+            .optional()
+            .describe("Optional registrar-side registration certificate id."),
+        registrationCertBodyPrivacyPolicy: z
+            .string()
+            .nullable()
+            .optional()
+            .describe("Optional registration certificate privacy policy URI."),
+        registrationCertBodySupportUri: z
+            .string()
+            .nullable()
+            .optional()
+            .describe("Optional registration certificate support URI."),
+        registrationCertBodyIntermediary: z
+            .string()
+            .nullable()
+            .optional()
+            .describe("Optional registration certificate intermediary."),
+        registrationCertBodyPurpose: z
+            .array(RegistrationCertificateFormPurposeSchema)
+            .nullable()
+            .optional()
+            .describe("Optional registration certificate purpose entries."),
         webhookEndpointId: z
             .string()
             .nullable()

--- a/apps/cli/templates/schemas/CredentialConfigCreate.schema.json
+++ b/apps/cli/templates/schemas/CredentialConfigCreate.schema.json
@@ -285,6 +285,35 @@
       "description": "Enable status management for issued credentials.",
       "type": "boolean"
     },
+    "activeCredentials": {
+      "description": "Optional issuer-side policy limiting simultaneously active credentials per subject. Requires statusManagement.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Ensure a subject has at most one active credential of this configuration."
+            },
+            "tracking": {
+              "description": "How the subject's active credential set is tracked. Only 'internal' (pseudonymous, issuer-side) is currently supported.",
+              "type": "string",
+              "enum": [
+                "internal"
+              ]
+            }
+          },
+          "required": [
+            "enabled"
+          ],
+          "additionalProperties": false,
+          "description": "Issuer-side policy limiting the number of simultaneously active credentials per subject."
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "iaeActions": {
       "description": "Optional in-app experience actions for wallet flows.",
       "anyOf": [
@@ -624,6 +653,7 @@
     "fields"
   ],
   "additionalProperties": false,
+  "description": "Payload for creating credential issuance configuration.",
   "$defs": {
     "__schema0": {
       "type": "object",

--- a/apps/cli/templates/schemas/PresentationConfigCreateDto.schema.json
+++ b/apps/cli/templates/schemas/PresentationConfigCreateDto.schema.json
@@ -440,28 +440,35 @@
     },
     "transaction_data": {
       "description": "Optional transaction data descriptors.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "description": "Transaction data type identifier."
-          },
-          "credential_ids": {
-            "type": "array",
-            "items": {
-              "type": "string"
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Transaction data type identifier."
+              },
+              "credential_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Credential query ids this transaction data applies to."
+              }
             },
-            "description": "Credential query ids this transaction data applies to."
+            "required": [
+              "type",
+              "credential_ids"
+            ],
+            "additionalProperties": {}
           }
         },
-        "required": [
-          "type",
-          "credential_ids"
-        ],
-        "additionalProperties": {}
-      }
+        {
+          "type": "null"
+        }
+      ]
     },
     "registration_cert": {
       "description": "Optional registration certificate request settings.",
@@ -531,6 +538,84 @@
             }
           },
           "additionalProperties": false
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "registrationCertImportJwt": {
+      "description": "Optional imported registration certificate JWT.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "registrationCertImportId": {
+      "description": "Optional registrar-side registration certificate id.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "registrationCertBodyPrivacyPolicy": {
+      "description": "Optional registration certificate privacy policy URI.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "registrationCertBodySupportUri": {
+      "description": "Optional registration certificate support URI.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "registrationCertBodyIntermediary": {
+      "description": "Optional registration certificate intermediary.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "registrationCertBodyPurpose": {
+      "description": "Optional registration certificate purpose entries.",
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "lang": {
+                "type": "string"
+              },
+              "content": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
         },
         {
           "type": "null"

--- a/apps/client/src/app/utils/schemas.json
+++ b/apps/client/src/app/utils/schemas.json
@@ -10580,6 +10580,84 @@
             }
           ]
         },
+        "registrationCertImportJwt": {
+          "description": "Optional imported registration certificate JWT.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "registrationCertImportId": {
+          "description": "Optional registrar-side registration certificate id.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "registrationCertBodyPrivacyPolicy": {
+          "description": "Optional registration certificate privacy policy URI.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "registrationCertBodySupportUri": {
+          "description": "Optional registration certificate support URI.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "registrationCertBodyIntermediary": {
+          "description": "Optional registration certificate intermediary.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "registrationCertBodyPurpose": {
+          "description": "Optional registration certificate purpose entries.",
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "lang": {
+                    "type": "string"
+                  },
+                  "content": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "webhookEndpointId": {
           "description": "Optional webhook endpoint id for presentation callbacks.",
           "anyOf": [

--- a/schemas/PresentationConfigCreateDto.schema.json
+++ b/schemas/PresentationConfigCreateDto.schema.json
@@ -544,6 +544,84 @@
         }
       ]
     },
+    "registrationCertImportJwt": {
+      "description": "Optional imported registration certificate JWT.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "registrationCertImportId": {
+      "description": "Optional registrar-side registration certificate id.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "registrationCertBodyPrivacyPolicy": {
+      "description": "Optional registration certificate privacy policy URI.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "registrationCertBodySupportUri": {
+      "description": "Optional registration certificate support URI.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "registrationCertBodyIntermediary": {
+      "description": "Optional registration certificate intermediary.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "registrationCertBodyPurpose": {
+      "description": "Optional registration certificate purpose entries.",
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "lang": {
+                "type": "string"
+              },
+              "content": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "webhookEndpointId": {
       "description": "Optional webhook endpoint id for presentation callbacks.",
       "anyOf": [


### PR DESCRIPTION
## 📝 Description

Accept registration certificate form fields in the presentation configuration API after the Zod schema migration, normalize them into the canonical `registration_cert` shape before persistence, and keep generated schemas in sync.

Fixes #(issue number)

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test improvements
- [x] 🏗️ Build/CI changes

## 💥 Breaking Changes (if applicable)

None.

## 🧪 Testing

- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] E2E tests pass
- [x] Manual testing performed

**Test Configuration**:

- Node.js version: repository default/local Node 22 environment
- OS: macOS
- Test environment: local workspace

Commands run:

- `pnpm --filter @eudiplo/client lint`
- `pnpm --filter @eudiplo/client build`
- backend schema regression test for `presentation-config.schema.spec.ts`
- `pnpm --filter @eudiplo/backend lint`
- `pnpm --filter @eudiplo/backend build`
- `pnpm --filter @eudiplo/cli assets:check`
- `pnpm build`
- `pnpm --filter @eudiplo/backend exec node -e "console.log(require.resolve('multer'))"`

## 📸 Screenshots (if applicable)

Not applicable.

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 📋 Additional Notes

The backend `multer` resolution issue could not be reproduced after refreshing dependencies/build outputs; `multer` resolves successfully from the backend workspace and the full workspace build passes.