### PR TITLE
Fix Kubernetes deployment profiles

### DIFF
--- a/apps/docs/docs/deployment/kubernetes.md
+++ b/apps/docs/docs/deployment/kubernetes.md
@@ -7,7 +7,7 @@ import TabItem from "@theme/TabItem";
 
 # Kubernetes Deployment
 
-Deploy EUDIPLO on Kubernetes with PostgreSQL and MinIO for production use.
+Deploy EUDIPLO on Kubernetes with Kustomize deployment profiles for local, staging, and production-oriented environments.
 
 ## Architecture
 
@@ -15,16 +15,27 @@ The Kubernetes deployment includes:
 
 - **EUDIPLO Backend** — Main application service (Node.js)
 - **EUDIPLO Client** — Web UI served by nginx
-- **PostgreSQL** — Relational database with persistent storage
-- **MinIO** — S3-compatible object storage
-- **Ingress** — HTTP routing with domain-based access
+- **PostgreSQL** — Optional relational database with persistent storage
+- **MinIO** — Optional S3-compatible object storage
+- **Vault** — Optional development-only key and encryption-key store
+- **Ingress** — nginx HTTP routing with domain-based access
 
 All components include:
 
 - ✅ Security contexts (non-root users)
 - ✅ Health probes (readiness, liveness, startup)
-- ✅ Resource limits (CPU/memory)
+- ✅ Resource limits (CPU/memory/ephemeral storage)
 - ✅ Persistent storage (StatefulSets with PVCs)
+
+## Deployment Profiles
+
+| Profile | Components | Intended use |
+| --- | --- | --- |
+| `minimal` | EUDIPLO, SQLite, local storage | Local development and quick testing |
+| `standard` | EUDIPLO, PostgreSQL, MinIO | Staging and small deployments |
+| `full` | Standard profile plus Vault | Local testing of Vault integration |
+
+Use an external managed database, object store, and Vault for production. The bundled PostgreSQL, MinIO, and Vault workloads are single-replica development deployments.
 
 ## Prerequisites
 
@@ -62,7 +73,7 @@ Ensure you have:
 
 ### Install ingress-nginx Controller
 
-Required for accessing services via domain names:
+The manifests set `ingressClassName: nginx`; install ingress-nginx to access services through the configured domain names:
 
 ```bash
 # Install ingress-nginx
@@ -77,9 +88,11 @@ kubectl wait --namespace ingress-nginx \
 
 ### Configure Environment
 
+Choose a profile and copy its environment example. This example uses the standard profile:
+
 ```bash
 cd deployment/k8s
-cp .env.example .env
+cp overlays/standard/.env.example overlays/standard/.env
 ```
 
 Edit `.env`:
@@ -88,11 +101,8 @@ Edit `.env`:
 # Public URL (for OAuth redirects and OIDC)
 PUBLIC_URL=http://eudiplo.localtest.me
 
-# Internal backend URL for self-JWKS verification (default shown)
-# Change only when the backend is not listening on port 3000 in this pod.
-INTERNAL_URL=http://127.0.0.1:3000
-
 # PostgreSQL Configuration
+DB_TYPE=postgres
 DB_USERNAME=eudiplo
 DB_PASSWORD=changeme123
 DB_DATABASE=eudiplo
@@ -101,6 +111,10 @@ DB_DATABASE=eudiplo
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=minioadmin123
 MINIO_BUCKET=uploads
+S3_REGION=us-east-1
+S3_ACCESS_KEY_ID=minioadmin
+S3_SECRET_ACCESS_KEY=minioadmin123
+S3_BUCKET=uploads
 
 # Application Secrets
 MASTER_SECRET=your-secret-jwt-key-change-in-production
@@ -124,18 +138,35 @@ The demo credentials will trigger security warnings in the application logs. **A
 kubectl create namespace eudiplo
 
 # Create Kubernetes secret from .env file
-kubectl -n eudiplo create secret generic eudiplo-env --from-env-file=.env
+kubectl -n eudiplo create secret generic eudiplo-env --from-env-file=overlays/standard/.env
 ```
 
 ### 2. Deploy All Resources
 
-Using Kustomize (recommended):
+Using Kustomize profiles (recommended):
 
 ```bash
-kubectl apply -k .
+# Standard profile: PostgreSQL and MinIO
+kubectl apply -k overlays/standard
 ```
 
-Or apply individual manifests:
+For a minimal local deployment:
+
+```bash
+cp overlays/minimal/.env.example overlays/minimal/.env
+kubectl -n eudiplo create secret generic eudiplo-env \
+    --from-env-file=overlays/minimal/.env \
+    --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -k overlays/minimal
+```
+
+The full profile also requires `VAULT_TOKEN` from `overlays/full/.env.example` and creates a development Vault encryption key automatically:
+
+```bash
+kubectl apply -k overlays/full
+```
+
+Legacy flat manifests remain available for backwards compatibility:
 
 ```bash
 kubectl apply -f namespace.yaml
@@ -280,6 +311,8 @@ kubectl -n ingress-nginx get pods
 kubectl -n eudiplo describe ingress eudiplo-ingress
 ```
 
+The bundled ingress requires the `nginx` ingress class. For a different controller, change `spec.ingressClassName` in the ingress manifest or apply an overlay patch.
+
 Fallback to port-forward (see above).
 
 ### Database Connection Errors
@@ -294,6 +327,14 @@ Restart backend if credentials were updated:
 
 ```bash
 kubectl -n eudiplo rollout restart deployment/eudiplo
+```
+
+### Docker Desktop Kubernetes Certificate Expired
+
+If `kubectl` reports an expired certificate for `https://127.0.0.1:6443`, the Docker Desktop Kubernetes API server certificate has expired. This is local cluster state, not an EUDIPLO certificate. Reset or update Kubernetes from Docker Desktop settings, then verify it with:
+
+```bash
+kubectl cluster-info
 ```
 
 ## Related Topics

--- a/deployment/k8s/README.md
+++ b/deployment/k8s/README.md
@@ -44,7 +44,7 @@ k8s/
 # Navigate to the k8s directory
 cd deployment/k8s
 
-# Choose your overlay and copy the example env
+# Choose your overlay and copy its example env
 cp overlays/standard/.env.example overlays/standard/.env
 # Edit with your configuration
 nano overlays/standard/.env
@@ -147,5 +147,10 @@ kubectl -n eudiplo port-forward svc/eudiplo 3000:3000
 3. **Enable TLS** via cert-manager
 4. **Configure resource limits**
 5. **Set up monitoring** (Prometheus, Grafana)
+6. **Pin application images** to a tested release or digest before upgrading
+
+The full overlay deploys Vault in development mode and creates its encryption key
+automatically. Use an externally managed, initialized Vault instance with a
+restricted token for production.
 
 👉 **[Read the full documentation](https://openwallet-foundation.github.io/eudiplo/docs/latest/deployment/kubernetes/)**

--- a/deployment/k8s/base/eudiplo-client-deployment.yaml
+++ b/deployment/k8s/base/eudiplo-client-deployment.yaml
@@ -37,7 +37,7 @@ spec:
               echo "eudiplo is up."
       containers:
         - name: eudiplo-client
-          image: ghcr.io/openwallet-foundation/eudiplo-client:latest
+          image: ghcr.io/openwallet-foundation/eudiplo-client:v7.4.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -73,9 +73,11 @@ spec:
             requests:
               cpu: "50m"
               memory: "64Mi"
+              ephemeral-storage: "128Mi"
             limits:
               cpu: "250m"
               memory: "256Mi"
+              ephemeral-storage: "256Mi"
           env:
             - name: API_BASE_URL
               valueFrom:

--- a/deployment/k8s/base/eudiplo-deployment.yaml
+++ b/deployment/k8s/base/eudiplo-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: eudiplo
-          image: ghcr.io/openwallet-foundation/eudiplo:latest
+          image: ghcr.io/openwallet-foundation/eudiplo:v7.4.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000
@@ -31,6 +31,9 @@ spec:
             readOnlyRootFilesystem: false
             runAsNonRoot: true
           envFrom:
+            - configMapRef:
+                name: eudiplo-config
+                optional: true
             - secretRef:
                 name: eudiplo-env
           readinessProbe:
@@ -58,9 +61,11 @@ spec:
             requests:
               cpu: "100m"
               memory: "256Mi"
+              ephemeral-storage: "1Gi"
             limits:
               cpu: "500m"
               memory: "512Mi"
+              ephemeral-storage: "2Gi"
           volumeMounts:
             - name: uploads
               mountPath: /app/uploads

--- a/deployment/k8s/base/ingress.yaml
+++ b/deployment/k8s/base/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
     # Add your ingress controller annotations here
     # nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
+  ingressClassName: nginx
   rules:
     - host: eudiplo.localtest.me
       http:

--- a/deployment/k8s/components/vault/kustomization.yaml
+++ b/deployment/k8s/components/vault/kustomization.yaml
@@ -7,6 +7,7 @@ kind: Component
 resources:
   - vault-deployment.yaml
   - vault-service.yaml
+  - vault-bootstrap-job.yaml
 
 # Patch EUDIPLO deployment to use Vault for key management
 patches:
@@ -25,12 +26,18 @@ patches:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: VAULT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: eudiplo-env
+                  key: VAULT_TOKEN
           command:
             - sh
             - -c
             - |
-              until wget -qO- http://vault:8200/v1/sys/health >/dev/null 2>&1; do
-                echo "waiting for vault..."; sleep 3;
+              until wget -qO- --header="X-Vault-Token: $VAULT_TOKEN" http://vault:8200/v1/secret/data/eudiplo/encryption-key >/dev/null 2>&1; do
+                echo "waiting for Vault encryption key..."; sleep 3;
               done
       - op: add
         path: /spec/template/spec/containers/0/env/-

--- a/deployment/k8s/components/vault/vault-bootstrap-job.yaml
+++ b/deployment/k8s/components/vault/vault-bootstrap-job.yaml
@@ -1,0 +1,47 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: vault-bootstrap
+spec:
+  backoffLimit: 6
+  template:
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: OnFailure
+      securityContext:
+        runAsUser: 100
+        runAsNonRoot: true
+        fsGroup: 1000
+      containers:
+        - name: bootstrap
+          image: hashicorp/vault:1.18.3
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: VAULT_ADDR
+              value: http://vault:8200
+            - name: VAULT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: eudiplo-env
+                  key: VAULT_TOKEN
+          command:
+            - sh
+            - -c
+            - |
+              until vault status >/dev/null 2>&1; do
+                echo "waiting for Vault..."; sleep 3;
+              done
+              vault kv put secret/eudiplo/encryption-key key="$(head -c 32 /dev/urandom | base64)"
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"

--- a/deployment/k8s/components/vault/vault-deployment.yaml
+++ b/deployment/k8s/components/vault/vault-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: vault
-          image: hashicorp/vault:latest
+          image: hashicorp/vault:1.18.3
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8200

--- a/deployment/k8s/eudiplo-client-deployment.yaml
+++ b/deployment/k8s/eudiplo-client-deployment.yaml
@@ -38,7 +38,7 @@ spec:
               echo "eudiplo is up."
       containers:
         - name: eudiplo-client
-          image: ghcr.io/openwallet-foundation/eudiplo-client:latest
+          image: ghcr.io/openwallet-foundation/eudiplo-client:v7.4.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -74,6 +74,8 @@ spec:
             requests:
               cpu: "50m"
               memory: "64Mi"
+              ephemeral-storage: "128Mi"
             limits:
               cpu: "250m"
               memory: "256Mi"
+              ephemeral-storage: "256Mi"

--- a/deployment/k8s/eudiplo-deployment.yaml
+++ b/deployment/k8s/eudiplo-deployment.yaml
@@ -67,7 +67,7 @@ spec:
               done
       containers:
         - name: eudiplo
-          image: ghcr.io/openwallet-foundation/eudiplo:latest
+          image: ghcr.io/openwallet-foundation/eudiplo:v7.4.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000
@@ -113,6 +113,8 @@ spec:
             requests:
               cpu: "100m"
               memory: "256Mi"
+              ephemeral-storage: "1Gi"
             limits:
               cpu: "500m"
               memory: "512Mi"
+              ephemeral-storage: "2Gi"

--- a/deployment/k8s/ingress.yaml
+++ b/deployment/k8s/ingress.yaml
@@ -4,6 +4,7 @@ metadata:
   name: eudiplo-ingress
   namespace: eudiplo
 spec:
+  ingressClassName: nginx
   rules:
     - host: eudiplo.localtest.me
       http:


### PR DESCRIPTION
Makes the Kubernetes deployment profiles reproducible and runnable locally.

- pin EUDIPLO and Vault images to tested versions
- select the nginx ingress class explicitly
- consume minimal-profile configuration and set ephemeral-storage limits
- bootstrap the Vault encryption key before the backend starts
- align the published Kubernetes guide with overlay-based deployment and Docker Desktop certificate recovery

Validation:
- `pnpm --dir apps/docs build`
- `kubectl kustomize deployment/k8s`
- `kubectl kustomize deployment/k8s/overlays/minimal`
- `kubectl kustomize deployment/k8s/overlays/standard`
- `kubectl kustomize deployment/k8s/overlays/full`

The local Docker Desktop API certificate expiry is documented as cluster state, not an EUDIPLO certificate.

Breaking Changes: None.