### PR TITLE
Fix expiry status for presentation sessions

### DIFF
--- a/apps/backend/src/session/session.service.spec.ts
+++ b/apps/backend/src/session/session.service.spec.ts
@@ -1,0 +1,81 @@
+import "reflect-metadata";
+import { ConfigService } from "@nestjs/config";
+import { EventEmitter2 } from "@nestjs/event-emitter";
+import { SchedulerRegistry } from "@nestjs/schedule";
+import { MetricService } from "nestjs-otel";
+import { Repository } from "typeorm";
+import { describe, expect, test, vi } from "vitest";
+import { TenantEntity } from "../auth/tenant/entities/tenant.entity";
+import { Session, SessionStatus } from "./entities/session.entity";
+import { SessionService } from "./session.service";
+import { SESSION_STATUS_CHANGED } from "./session-events.service";
+
+describe("SessionService", () => {
+    test("expires overdue presentation sessions and emits their status changes", async () => {
+        const expiredSessions = [
+            {
+                id: "active-session",
+                tenantId: "tenant-1",
+                requestId: "request-1",
+                status: SessionStatus.Active,
+            },
+            {
+                id: "fetched-session",
+                tenantId: "tenant-1",
+                requestId: "request-2",
+                status: SessionStatus.Fetched,
+            },
+        ] as Session[];
+        const sessionRepository = {
+            findBy: vi.fn().mockResolvedValue(expiredSessions),
+            update: vi.fn().mockResolvedValue({ affected: 1 }),
+        } as unknown as Repository<Session>;
+        const tenantRepository = {
+            find: vi.fn().mockResolvedValue([]),
+        } as unknown as Repository<TenantEntity>;
+        const eventEmitter = { emit: vi.fn() } as unknown as EventEmitter2;
+        const metricCounter = { add: vi.fn() };
+        const service = new SessionService(
+            sessionRepository,
+            tenantRepository,
+            {
+                getOrThrow: vi.fn((key: string) =>
+                    key === "SESSION_TTL" ? 3600 : "full",
+                ),
+            } as unknown as ConfigService,
+            {} as SchedulerRegistry,
+            eventEmitter,
+            {
+                getUpDownCounter: vi.fn().mockReturnValue(metricCounter),
+            } as unknown as MetricService,
+        );
+
+        await service.tidyUpSessions();
+
+        expect(sessionRepository.findBy).toHaveBeenCalledOnce();
+        expect(sessionRepository.update).toHaveBeenCalledTimes(2);
+        expect(sessionRepository.update).toHaveBeenCalledWith(
+            { id: "active-session" },
+            { status: SessionStatus.Expired },
+        );
+        expect(sessionRepository.update).toHaveBeenCalledWith(
+            { id: "fetched-session" },
+            { status: SessionStatus.Expired },
+        );
+        expect(eventEmitter.emit).toHaveBeenCalledTimes(2);
+        expect(eventEmitter.emit).toHaveBeenCalledWith(
+            SESSION_STATUS_CHANGED,
+            expect.objectContaining({
+                sessionId: "active-session",
+                status: SessionStatus.Expired,
+            }),
+        );
+        expect(eventEmitter.emit).toHaveBeenCalledWith(
+            SESSION_STATUS_CHANGED,
+            expect.objectContaining({
+                sessionId: "fetched-session",
+                status: SessionStatus.Expired,
+            }),
+        );
+    });
+});

--- a/apps/backend/src/session/session.service.ts
+++ b/apps/backend/src/session/session.service.ts
@@ -8,6 +8,7 @@ import { MetricService } from "nestjs-otel";
 import {
     DeepPartial,
     FindOptionsWhere,
+    In,
     IsNull,
     LessThan,
     Not,
@@ -294,6 +295,8 @@ export class SessionService implements OnApplicationBootstrap {
      * - 'anonymize' mode: Keeps session metadata but removes personal data
      */
     async tidyUpSessions() {
+        await this.expirePresentationSessions();
+
         const defaultTtlSeconds =
             this.configService.getOrThrow<number>("SESSION_TTL");
         const defaultCleanupMode = this.configService.getOrThrow<string>(
@@ -305,51 +308,11 @@ export class SessionService implements OnApplicationBootstrap {
 
         // Process each tenant with their specific config
         for (const tenant of tenants) {
-            const ttlSeconds =
-                tenant.sessionConfig?.ttlSeconds ?? defaultTtlSeconds;
-            const cutoffDate = new Date(Date.now() - ttlSeconds * 1000);
-            const cleanupMode =
-                tenant.sessionConfig?.cleanupMode ?? defaultCleanupMode;
-
-            if (cleanupMode === SessionCleanupMode.Anonymize) {
-                // Anonymize: Keep session metadata (including original status) but remove personal data
-                // We use a raw query to only target sessions that still have personal data
-                const result = await this.sessionRepository
-                    .createQueryBuilder()
-                    .update()
-                    .set({
-                        // Clear personal data fields
-                        credentials: undefined,
-                        credentialPayload: undefined,
-                        auth_queries: undefined,
-                        offer: undefined,
-                        requestObject: undefined,
-                        responseEncryptionPrivateJwk: undefined,
-                    })
-                    .where("tenantId = :tenantId", { tenantId: tenant.id })
-                    .andWhere("createdAt < :cutoffDate", { cutoffDate })
-                    // Only anonymize sessions that still have personal data
-                    .andWhere(
-                        "(credentials IS NOT NULL OR credentialPayload IS NOT NULL OR auth_queries IS NOT NULL OR offer IS NOT NULL OR requestObject IS NOT NULL OR responseEncryptionPrivateJwk IS NOT NULL)",
-                    )
-                    .execute();
-                if (result.affected && result.affected > 0) {
-                    this.logger.log(
-                        `Anonymized ${result.affected} sessions for tenant ${tenant.id}`,
-                    );
-                }
-            } else {
-                // Full delete (default behavior)
-                const result = await this.sessionRepository.delete({
-                    tenantId: tenant.id,
-                    createdAt: LessThan(cutoffDate),
-                });
-                if (result.affected && result.affected > 0) {
-                    this.logger.log(
-                        `Deleted ${result.affected} sessions for tenant ${tenant.id}`,
-                    );
-                }
-            }
+            await this.tidyUpTenantSessions(
+                tenant,
+                defaultTtlSeconds,
+                defaultCleanupMode,
+            );
         }
 
         // Also clean up sessions for tenants that no longer exist (orphaned sessions)
@@ -368,6 +331,66 @@ export class SessionService implements OnApplicationBootstrap {
                     `Deleted ${orphanedResult.affected} orphaned sessions`,
                 );
             }
+        }
+    }
+
+    private async tidyUpTenantSessions(
+        tenant: TenantEntity,
+        defaultTtlSeconds: number,
+        defaultCleanupMode: string,
+    ) {
+        const ttlSeconds =
+            tenant.sessionConfig?.ttlSeconds ?? defaultTtlSeconds;
+        const cutoffDate = new Date(Date.now() - ttlSeconds * 1000);
+        const cleanupMode =
+            tenant.sessionConfig?.cleanupMode ?? defaultCleanupMode;
+
+        if (cleanupMode === SessionCleanupMode.Anonymize) {
+            const result = await this.sessionRepository
+                .createQueryBuilder()
+                .update()
+                .set({
+                    credentials: undefined,
+                    credentialPayload: undefined,
+                    auth_queries: undefined,
+                    offer: undefined,
+                    requestObject: undefined,
+                    responseEncryptionPrivateJwk: undefined,
+                })
+                .where("tenantId = :tenantId", { tenantId: tenant.id })
+                .andWhere("createdAt < :cutoffDate", { cutoffDate })
+                .andWhere(
+                    "(credentials IS NOT NULL OR credentialPayload IS NOT NULL OR auth_queries IS NOT NULL OR offer IS NOT NULL OR requestObject IS NOT NULL OR responseEncryptionPrivateJwk IS NOT NULL)",
+                )
+                .execute();
+            if (result.affected && result.affected > 0) {
+                this.logger.log(
+                    `Anonymized ${result.affected} sessions for tenant ${tenant.id}`,
+                );
+            }
+            return;
+        }
+
+        const result = await this.sessionRepository.delete({
+            tenantId: tenant.id,
+            createdAt: LessThan(cutoffDate),
+        });
+        if (result.affected && result.affected > 0) {
+            this.logger.log(
+                `Deleted ${result.affected} sessions for tenant ${tenant.id}`,
+            );
+        }
+    }
+
+    private async expirePresentationSessions() {
+        const expiredSessions = await this.sessionRepository.findBy({
+            expiresAt: LessThan(new Date()),
+            requestId: Not(IsNull()),
+            status: In([SessionStatus.Active, SessionStatus.Fetched]),
+        });
+
+        for (const session of expiredSessions) {
+            await this.setState(session, SessionStatus.Expired);
         }
     }
 

--- a/apps/docs/docs/deployment/kubernetes.md
+++ b/apps/docs/docs/deployment/kubernetes.md
@@ -29,11 +29,11 @@ All components include:
 
 ## Deployment Profiles
 
-| Profile | Components | Intended use |
-| --- | --- | --- |
-| `minimal` | EUDIPLO, SQLite, local storage | Local development and quick testing |
-| `standard` | EUDIPLO, PostgreSQL, MinIO | Staging and small deployments |
-| `full` | Standard profile plus Vault | Local testing of Vault integration |
+| Profile    | Components                     | Intended use                        |
+| ---------- | ------------------------------ | ----------------------------------- |
+| `minimal`  | EUDIPLO, SQLite, local storage | Local development and quick testing |
+| `standard` | EUDIPLO, PostgreSQL, MinIO     | Staging and small deployments       |
+| `full`     | Standard profile plus Vault    | Local testing of Vault integration  |
 
 Use an external managed database, object store, and Vault for production. The bundled PostgreSQL, MinIO, and Vault workloads are single-replica development deployments.
 


### PR DESCRIPTION
Presentation sessions whose `expiresAt` has elapsed now transition to `expired` during the scheduled session lifecycle.

- Restrict expiry transitions to active or fetched presentation sessions
- Emit the existing session status event so SSE subscribers receive the terminal state
- Add focused session-service coverage
- Extract tenant retention cleanup to preserve SonarQube complexity limits

Fixes #972