### PR TITLE
feat(client): add configurable dashboard views

### DIFF
--- a/apps/client/src/app/dashboard/dashboard-preferences.service.spec.ts
+++ b/apps/client/src/app/dashboard/dashboard-preferences.service.spec.ts
@@ -1,0 +1,74 @@
+import { ApiService } from '../core';
+import { JwtService, type JWTPayload } from '../services/jwt.service';
+import { DashboardPreferences, DashboardPreferencesService } from './dashboard-preferences.service';
+
+describe('DashboardPreferencesService', () => {
+  const defaults: DashboardPreferences = {
+    focus: 'balanced',
+    visibleSections: {
+      recentActivity: true,
+      sessionOverview: true,
+      quickActions: true,
+      resources: true,
+    },
+  };
+
+  let payload: JWTPayload;
+  let service: DashboardPreferencesService;
+
+  beforeEach(() => {
+    const entries = new Map<string, string>();
+    const storage = {
+      get length() {
+        return entries.size;
+      },
+      clear: () => entries.clear(),
+      getItem: (key: string) => entries.get(key) ?? null,
+      key: (index: number) => [...entries.keys()][index] ?? null,
+      removeItem: (key: string) => entries.delete(key),
+      setItem: (key: string, value: string) => entries.set(key, value),
+    } as Storage;
+    Object.defineProperty(globalThis, 'localStorage', { configurable: true, value: storage });
+    localStorage.clear();
+    payload = { sub: 'user-a', tenant_id: 'tenant-a', roles: [] };
+    const apiService = { accessToken: 'token' } as ApiService;
+    const jwtService = { decodeToken: () => payload } as unknown as JwtService;
+    service = new DashboardPreferencesService(apiService, jwtService);
+  });
+
+  it('returns role-based defaults when no preferences are saved', () => {
+    expect(service.load(defaults)).toEqual(defaults);
+  });
+
+  it('persists dashboard preferences for the current user', () => {
+    const preferences: DashboardPreferences = {
+      focus: 'operations',
+      visibleSections: {
+        recentActivity: true,
+        sessionOverview: true,
+        quickActions: false,
+        resources: false,
+      },
+    };
+
+    service.save(preferences);
+
+    expect(service.load(defaults)).toEqual(preferences);
+  });
+
+  it('keeps preferences separate between users', () => {
+    service.save({
+      ...defaults,
+      visibleSections: { ...defaults.visibleSections, resources: false },
+    });
+    payload = { sub: 'user-b', tenant_id: 'tenant-a', roles: [] };
+
+    expect(service.load(defaults)).toEqual(defaults);
+  });
+
+  it('falls back safely when stored preferences are malformed', () => {
+    localStorage.setItem('eudiplo.dashboard.preferences.v1.tenant-a.user-a', '{broken');
+
+    expect(service.load(defaults)).toEqual(defaults);
+  });
+});

--- a/apps/client/src/app/dashboard/dashboard-preferences.service.ts
+++ b/apps/client/src/app/dashboard/dashboard-preferences.service.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@angular/core';
+
+import { ApiService } from '../core';
+import { JwtService } from '../services/jwt.service';
+
+export type DashboardFocus = 'balanced' | 'issuance' | 'verification' | 'operations';
+export type DashboardSection = 'recentActivity' | 'sessionOverview' | 'quickActions' | 'resources';
+
+export interface DashboardPreferences {
+  focus: DashboardFocus;
+  visibleSections: Record<DashboardSection, boolean>;
+}
+
+const storagePrefix = 'eudiplo.dashboard.preferences.v1';
+
+@Injectable({ providedIn: 'root' })
+export class DashboardPreferencesService {
+  constructor(
+    private readonly apiService: ApiService,
+    private readonly jwtService: JwtService
+  ) {}
+
+  load(defaults: DashboardPreferences): DashboardPreferences {
+    try {
+      const raw = localStorage.getItem(this.storageKey);
+      if (!raw) return defaults;
+
+      const saved = JSON.parse(raw) as Partial<DashboardPreferences>;
+      if (!this.isFocus(saved.focus)) return defaults;
+
+      return {
+        focus: saved.focus,
+        visibleSections: {
+          recentActivity:
+            saved.visibleSections?.recentActivity ?? defaults.visibleSections.recentActivity,
+          sessionOverview:
+            saved.visibleSections?.sessionOverview ?? defaults.visibleSections.sessionOverview,
+          quickActions:
+            saved.visibleSections?.quickActions ?? defaults.visibleSections.quickActions,
+          resources: saved.visibleSections?.resources ?? defaults.visibleSections.resources,
+        },
+      };
+    } catch {
+      return defaults;
+    }
+  }
+
+  save(preferences: DashboardPreferences): void {
+    try {
+      localStorage.setItem(this.storageKey, JSON.stringify(preferences));
+    } catch {
+      // The dashboard remains usable when storage is blocked or unavailable.
+    }
+  }
+
+  reset(): void {
+    try {
+      localStorage.removeItem(this.storageKey);
+    } catch {
+      // The in-memory reset still applies when storage is unavailable.
+    }
+  }
+
+  private get storageKey(): string {
+    const payload = this.jwtService.decodeToken(this.apiService.accessToken);
+    const tenant = payload?.tenant_id || 'default';
+    const user = payload?.sub || payload?.preferred_username || 'anonymous';
+    return `${storagePrefix}.${encodeURIComponent(tenant)}.${encodeURIComponent(user)}`;
+  }
+
+  private isFocus(value: unknown): value is DashboardFocus {
+    return ['balanced', 'issuance', 'verification', 'operations'].includes(String(value));
+  }
+}

--- a/apps/client/src/app/dashboard/dashboard.component.html
+++ b/apps/client/src/app/dashboard/dashboard.component.html
@@ -1,25 +1,126 @@
 <div fxLayout="column" fxLayoutAlign="start center" fxFill class="dashboard-container">
-  <!-- Welcome Header -->
+  <!-- Dashboard Header -->
   <div class="welcome-header" fxLayout="row" fxLayoutAlign="space-between center" fxFill>
-    <div>
-      <h1>Welcome to EUDIPLO</h1>
-      <p class="subtitle">Your Diplomatic Layer for EUDI Wallet Integration</p>
+    <div class="dashboard-heading">
+      <div class="heading-row">
+        <h1>Dashboard</h1>
+        <span class="focus-badge">{{ focusLabel }}</span>
+      </div>
+      <p class="subtitle" [class.needs-attention]="dashboardService.hasWarnings">
+        {{ readinessTitle }}
+      </p>
     </div>
-    <div class="version-chips" fxLayout="row" fxLayoutGap="8px">
-      <mat-chip color="primary" highlighted matTooltip="Backend version">
-        <mat-icon matChipAvatar>dns</mat-icon>
-        Backend: {{ backendVersion || '...' }}
-      </mat-chip>
-      <mat-chip color="accent" highlighted matTooltip="Client version">
-        <mat-icon matChipAvatar>web</mat-icon>
-        Client: {{ clientVersion || '...' }}
-      </mat-chip>
-      <mat-chip color="primary" highlighted matTooltip="Startup configuration import mode">
-        <mat-icon matChipAvatar>sync</mat-icon>
-        Import: {{ frontendConfigService.configImportMode || '...' }}
-      </mat-chip>
+    <div class="header-actions">
+      <div class="version-chips" fxLayout="row" fxLayoutGap="8px">
+        <mat-chip matTooltip="Backend version">
+          <mat-icon matChipAvatar>dns</mat-icon>
+          Backend: {{ backendVersion || '...' }}
+        </mat-chip>
+        <mat-chip matTooltip="Client version">
+          <mat-icon matChipAvatar>web</mat-icon>
+          Client: {{ clientVersion || '...' }}
+        </mat-chip>
+        <mat-chip matTooltip="Startup configuration import mode">
+          <mat-icon matChipAvatar>sync</mat-icon>
+          Import: {{ frontendConfigService.configImportMode || '...' }}
+        </mat-chip>
+      </div>
+      <button
+        mat-stroked-button
+        type="button"
+        class="customize-button"
+        (click)="customizePanelOpen = !customizePanelOpen"
+        [attr.aria-expanded]="customizePanelOpen"
+        aria-controls="dashboard-customization"
+      >
+        <mat-icon>tune</mat-icon>
+        Customize
+      </button>
     </div>
   </div>
+
+  @if (customizePanelOpen) {
+    <mat-card id="dashboard-customization" class="customization-card">
+      <mat-card-header>
+        <mat-icon mat-card-avatar>tune</mat-icon>
+        <mat-card-title>Customize dashboard</mat-card-title>
+        <mat-card-subtitle>Choose a focus, then fine-tune the visible sections</mat-card-subtitle>
+      </mat-card-header>
+      <mat-card-content>
+        <div class="customization-grid">
+          <section aria-labelledby="dashboard-focus-heading">
+            <h3 id="dashboard-focus-heading">Dashboard focus</h3>
+            <div class="focus-options">
+              @for (option of focusOptions; track option.value) {
+                <button
+                  type="button"
+                  class="focus-option"
+                  [class.selected]="preferences.focus === option.value"
+                  [disabled]="!option.available"
+                  [attr.aria-pressed]="preferences.focus === option.value"
+                  (click)="setFocus(option.value)"
+                >
+                  <mat-icon>{{ option.icon }}</mat-icon>
+                  <span>
+                    <strong>{{ option.label }}</strong>
+                    <small>{{ option.description }}</small>
+                  </span>
+                  @if (preferences.focus === option.value) {
+                    <mat-icon class="selected-icon">check_circle</mat-icon>
+                  }
+                </button>
+              }
+            </div>
+          </section>
+
+          <section aria-labelledby="visible-sections-heading">
+            <h3 id="visible-sections-heading">Visible sections</h3>
+            <div class="section-toggles">
+              <mat-checkbox
+                [checked]="isSectionVisible('recentActivity')"
+                [disabled]="!dashboardService.canViewSessions"
+                (change)="setSectionVisibility('recentActivity', $event.checked)"
+              >
+                Recent activity
+              </mat-checkbox>
+              <mat-checkbox
+                [checked]="isSectionVisible('sessionOverview')"
+                [disabled]="!dashboardService.canViewSessions"
+                (change)="setSectionVisibility('sessionOverview', $event.checked)"
+              >
+                Session overview
+              </mat-checkbox>
+              <mat-checkbox
+                [checked]="isSectionVisible('quickActions')"
+                (change)="setSectionVisibility('quickActions', $event.checked)"
+              >
+                Quick actions
+              </mat-checkbox>
+              <mat-checkbox
+                [checked]="isSectionVisible('resources')"
+                (change)="setSectionVisibility('resources', $event.checked)"
+              >
+                Documentation & resources
+              </mat-checkbox>
+            </div>
+            <p class="fixed-sections-note">
+              <mat-icon>lock</mat-icon>
+              System health and warnings always remain visible.
+            </p>
+          </section>
+        </div>
+      </mat-card-content>
+      <mat-card-actions align="end">
+        <button mat-button type="button" (click)="resetDashboard()">
+          <mat-icon>restart_alt</mat-icon>
+          Reset to default
+        </button>
+        <button mat-flat-button type="button" color="primary" (click)="customizePanelOpen = false">
+          Done
+        </button>
+      </mat-card-actions>
+    </mat-card>
+  }
 
   @if (dashboardService.isReadOnly && !dashboardService.isLoading) {
     <mat-card class="setup-card readonly-card">
@@ -327,11 +428,7 @@
         <mat-card class="stat-card">
           <mat-card-content fxLayout="column" fxLayoutAlign="center center">
             <mat-icon class="stat-icon sessions">sync</mat-icon>
-            <span class="stat-value">{{
-              dashboardService.sessionActive +
-                dashboardService.sessionCompleted +
-                dashboardService.sessionFetched
-            }}</span>
+            <span class="stat-value">{{ dashboardService.totalSessions }}</span>
             <span class="stat-label">Total Sessions</span>
           </mat-card-content>
         </mat-card>
@@ -434,9 +531,55 @@
     </mat-card>
   }
 
+  <!-- Recent session activity -->
+  @if (dashboardService.canViewSessions && isSectionVisible('recentActivity')) {
+    <mat-card class="recent-activity-card">
+      <mat-card-header>
+        <mat-icon mat-card-avatar>history</mat-icon>
+        <mat-card-title>Recent Activity</mat-card-title>
+        <mat-card-subtitle>Latest issuance and presentation session updates</mat-card-subtitle>
+      </mat-card-header>
+      <mat-card-content>
+        @if (dashboardService.recentSessions.length > 0) {
+          <div class="activity-list">
+            @for (session of dashboardService.recentSessions; track session.id) {
+              <a class="activity-row" routerLink="/session-management">
+                <mat-icon [class]="'activity-status status-' + session.status">
+                  {{ sessionStatusIcon(session.status) }}
+                </mat-icon>
+                <span class="activity-copy">
+                  <strong>Session {{ session.status }}</strong>
+                  <small>{{ session.id }}</small>
+                </span>
+                <time [attr.datetime]="session.updatedAt">
+                  {{ session.updatedAt | date: 'MMM d, HH:mm' }}
+                </time>
+                <mat-icon class="activity-arrow">chevron_right</mat-icon>
+              </a>
+            }
+          </div>
+        } @else if (!dashboardService.isLoading) {
+          <div class="empty-state">
+            <mat-icon>inbox</mat-icon>
+            <div>
+              <strong>No session activity yet</strong>
+              <p>Run an issuance or presentation flow to see recent updates here.</p>
+            </div>
+          </div>
+        }
+      </mat-card-content>
+      @if (dashboardService.recentSessions.length > 0) {
+        <mat-card-actions>
+          <a mat-button color="primary" routerLink="/session-management">View all sessions</a>
+        </mat-card-actions>
+      }
+    </mat-card>
+  }
+
   <!-- Session Status Breakdown -->
   @if (
     dashboardService.canViewSessions &&
+    isSectionVisible('sessionOverview') &&
     dashboardService.sessionActive +
       dashboardService.sessionCompleted +
       dashboardService.sessionFetched +
@@ -498,111 +641,124 @@
   }
 
   <!-- Quick Actions -->
-  <mat-card class="quick-actions-card">
-    <mat-card-header>
-      <mat-icon mat-card-avatar>flash_on</mat-icon>
-      <mat-card-title>Quick Actions</mat-card-title>
-      <mat-card-subtitle>Common tasks to get you started</mat-card-subtitle>
-    </mat-card-header>
-    <mat-card-content>
-      <div class="quick-actions" fxLayout="row wrap" fxLayoutGap="12px">
-        @if (jwtService.hasRole('issuance:offer')) {
-          <a
-            mat-raised-button
-            color="primary"
-            routerLink="/offer/issuance"
-            [class.disabled]="!dashboardService.isReadyToIssue"
-            [attr.tabindex]="!dashboardService.isReadyToIssue ? -1 : 0"
-            [matTooltip]="
-              !dashboardService.isReadyToIssue
-                ? dashboardService.issueReadinessReason || 'Issuance is not ready'
-                : 'Create an issuance offer'
-            "
-          >
-            <mat-icon>card_giftcard</mat-icon> Issue Credential
-          </a>
-        }
-        @if (jwtService.hasRole('presentation:request')) {
-          <a
-            mat-raised-button
-            color="accent"
-            routerLink="/offer/presentation"
-            [class.disabled]="!dashboardService.isReadyToVerify"
-            [attr.tabindex]="!dashboardService.isReadyToVerify ? -1 : 0"
-            [matTooltip]="
-              !dashboardService.isReadyToVerify
-                ? dashboardService.verifyReadinessReason || 'Presentation is not ready'
-                : 'Request a presentation'
-            "
-          >
-            <mat-icon>fact_check</mat-icon> Request Presentation
-          </a>
-        }
-        @if (dashboardService.canManageIssuance) {
-          <a mat-stroked-button routerLink="/credential-config/create">
-            <mat-icon>add_circle</mat-icon> New Credential Config
-          </a>
-        }
-        @if (dashboardService.canManagePresentation) {
-          <a mat-stroked-button routerLink="/presentation-config/create">
-            <mat-icon>playlist_add</mat-icon> New Presentation Config
-          </a>
-        }
-      </div>
-      @if (
-        (dashboardService.canManageIssuance && !dashboardService.isReadyToIssue) ||
-        (dashboardService.canManagePresentation && !dashboardService.isReadyToVerify)
-      ) {
-        <div class="actions-hint">
-          <mat-icon>info</mat-icon>
-          <span>
-            @if (dashboardService.canManageIssuance && dashboardService.issueReadinessReason) {
-              Issuance is blocked: <strong>{{ dashboardService.issueReadinessReason }}</strong
-              >.
-            }
-            @if (dashboardService.canManagePresentation && dashboardService.verifyReadinessReason) {
-              Presentation is blocked:
-              <strong>{{ dashboardService.verifyReadinessReason }}</strong
-              >.
-            }
-          </span>
+  @if (isSectionVisible('quickActions')) {
+    <mat-card class="quick-actions-card">
+      <mat-card-header>
+        <mat-icon mat-card-avatar>flash_on</mat-icon>
+        <mat-card-title>Quick Actions</mat-card-title>
+        <mat-card-subtitle>Common tasks to get you started</mat-card-subtitle>
+      </mat-card-header>
+      <mat-card-content>
+        <div class="quick-actions" fxLayout="row wrap" fxLayoutGap="12px">
+          @if (jwtService.hasRole('issuance:offer')) {
+            <a
+              mat-raised-button
+              color="primary"
+              [class.focus-first]="preferences.focus === 'issuance'"
+              routerLink="/offer/issuance"
+              [class.disabled]="!dashboardService.isReadyToIssue"
+              [attr.tabindex]="!dashboardService.isReadyToIssue ? -1 : 0"
+              [matTooltip]="
+                !dashboardService.isReadyToIssue
+                  ? dashboardService.issueReadinessReason || 'Issuance is not ready'
+                  : 'Create an issuance offer'
+              "
+            >
+              <mat-icon>card_giftcard</mat-icon> Issue Credential
+            </a>
+          }
+          @if (jwtService.hasRole('presentation:request')) {
+            <a
+              mat-raised-button
+              color="accent"
+              [class.focus-first]="preferences.focus === 'verification'"
+              routerLink="/offer/presentation"
+              [class.disabled]="!dashboardService.isReadyToVerify"
+              [attr.tabindex]="!dashboardService.isReadyToVerify ? -1 : 0"
+              [matTooltip]="
+                !dashboardService.isReadyToVerify
+                  ? dashboardService.verifyReadinessReason || 'Presentation is not ready'
+                  : 'Request a presentation'
+              "
+            >
+              <mat-icon>fact_check</mat-icon> Request Presentation
+            </a>
+          }
+          @if (dashboardService.canManageIssuance) {
+            <a mat-stroked-button routerLink="/credential-config/create">
+              <mat-icon>add_circle</mat-icon> New Credential Config
+            </a>
+          }
+          @if (dashboardService.canManagePresentation) {
+            <a mat-stroked-button routerLink="/presentation-config/create">
+              <mat-icon>playlist_add</mat-icon> New Presentation Config
+            </a>
+          }
         </div>
-      }
-    </mat-card-content>
-  </mat-card>
+        @if (
+          (dashboardService.canManageIssuance && !dashboardService.isReadyToIssue) ||
+          (dashboardService.canManagePresentation && !dashboardService.isReadyToVerify)
+        ) {
+          <div class="actions-hint">
+            <mat-icon>info</mat-icon>
+            <span>
+              @if (dashboardService.canManageIssuance && dashboardService.issueReadinessReason) {
+                Issuance is blocked: <strong>{{ dashboardService.issueReadinessReason }}</strong
+                >.
+              }
+              @if (
+                dashboardService.canManagePresentation && dashboardService.verifyReadinessReason
+              ) {
+                Presentation is blocked:
+                <strong>{{ dashboardService.verifyReadinessReason }}</strong
+                >.
+              }
+            </span>
+          </div>
+        }
+      </mat-card-content>
+    </mat-card>
+  }
 
   <!-- Resources & Documentation -->
-  <mat-card class="resources-card">
-    <mat-card-header>
-      <mat-icon mat-card-avatar>menu_book</mat-icon>
-      <mat-card-title>Documentation & Resources</mat-card-title>
-      <mat-card-subtitle>Learn more about EUDIPLO</mat-card-subtitle>
-    </mat-card-header>
-    <mat-card-content>
-      <div class="resource-links" fxLayout="row wrap" fxLayoutGap="16px">
-        <a mat-stroked-button href="https://docs.eudiplo.dev/" target="_blank" rel="noopener">
-          <mat-icon>description</mat-icon> Documentation
-        </a>
-        <a mat-stroked-button [href]="currentBaseUrl + '/api-docs'" target="_blank" rel="noopener">
-          <mat-icon>api</mat-icon> API Reference
-        </a>
-        <a
-          mat-stroked-button
-          href="https://github.com/openwallet-foundation/eudiplo"
-          target="_blank"
-          rel="noopener"
-        >
-          <mat-icon>code</mat-icon> GitHub
-        </a>
-        <a mat-stroked-button href="https://discord.gg/58ys8XfXDu" target="_blank" rel="noopener">
-          <mat-icon>forum</mat-icon> Discord Community
-        </a>
-        @if (grafanaEnabled) {
-          <button mat-stroked-button (click)="openGrafana()">
-            <mat-icon>monitoring</mat-icon> Grafana Dashboard
-          </button>
-        }
-      </div>
-    </mat-card-content>
-  </mat-card>
+  @if (isSectionVisible('resources')) {
+    <mat-card class="resources-card">
+      <mat-card-header>
+        <mat-icon mat-card-avatar>menu_book</mat-icon>
+        <mat-card-title>Documentation & Resources</mat-card-title>
+        <mat-card-subtitle>Learn more about EUDIPLO</mat-card-subtitle>
+      </mat-card-header>
+      <mat-card-content>
+        <div class="resource-links" fxLayout="row wrap" fxLayoutGap="16px">
+          <a mat-stroked-button href="https://docs.eudiplo.dev/" target="_blank" rel="noopener">
+            <mat-icon>description</mat-icon> Documentation
+          </a>
+          <a
+            mat-stroked-button
+            [href]="currentBaseUrl + '/api-docs'"
+            target="_blank"
+            rel="noopener"
+          >
+            <mat-icon>api</mat-icon> API Reference
+          </a>
+          <a
+            mat-stroked-button
+            href="https://github.com/openwallet-foundation/eudiplo"
+            target="_blank"
+            rel="noopener"
+          >
+            <mat-icon>code</mat-icon> GitHub
+          </a>
+          <a mat-stroked-button href="https://discord.gg/58ys8XfXDu" target="_blank" rel="noopener">
+            <mat-icon>forum</mat-icon> Discord Community
+          </a>
+          @if (grafanaEnabled) {
+            <button mat-stroked-button (click)="openGrafana()">
+              <mat-icon>monitoring</mat-icon> Grafana Dashboard
+            </button>
+          }
+        </div>
+      </mat-card-content>
+    </mat-card>
+  }
 </div>

--- a/apps/client/src/app/dashboard/dashboard.component.scss
+++ b/apps/client/src/app/dashboard/dashboard.component.scss
@@ -34,6 +34,16 @@ mat-icon[mat-card-avatar] {
   width: 100%;
   margin-bottom: 8px;
 
+  .dashboard-heading {
+    min-width: 220px;
+  }
+
+  .heading-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
   h1 {
     margin: 0;
     font-size: 28px;
@@ -45,6 +55,147 @@ mat-icon[mat-card-avatar] {
     margin: 4px 0 0;
     color: var(--mat-sys-on-surface-variant);
     font-size: 14px;
+
+    &.needs-attention {
+      color: var(--eudiplo-warning);
+      font-weight: 500;
+    }
+  }
+
+  .focus-badge {
+    padding: 4px 9px;
+    border-radius: 999px;
+    background: var(--mat-sys-primary-container);
+    color: var(--mat-sys-on-primary-container);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .version-chips mat-chip {
+    background: var(--mat-sys-surface-container-high);
+  }
+
+  .customize-button {
+    flex-shrink: 0;
+  }
+}
+
+// Lightweight personalization panel
+.customization-card {
+  width: 100%;
+  border: 1px solid var(--mat-sys-outline-variant);
+  background: var(--mat-sys-surface-container-low);
+
+  mat-icon[mat-card-avatar] {
+    color: var(--mat-sys-on-primary-container);
+    background: var(--mat-sys-primary-container);
+  }
+
+  .customization-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.7fr) minmax(240px, 1fr);
+    gap: 32px;
+    padding-top: 8px;
+  }
+
+  h3 {
+    margin: 0 0 12px;
+    color: var(--mat-sys-on-surface);
+    font-size: 14px;
+    font-weight: 600;
+  }
+
+  .focus-options {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+  }
+
+  .focus-option {
+    display: grid;
+    grid-template-columns: 24px minmax(0, 1fr) 20px;
+    align-items: center;
+    gap: 10px;
+    padding: 12px;
+    border: 1px solid var(--mat-sys-outline-variant);
+    border-radius: 10px;
+    background: var(--mat-sys-surface);
+    color: var(--mat-sys-on-surface);
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition:
+      border-color 0.15s ease,
+      background-color 0.15s ease;
+
+    &:hover:not(:disabled) {
+      background: var(--mat-sys-surface-container-high);
+      border-color: var(--mat-sys-outline);
+    }
+
+    &.selected {
+      background: var(--mat-sys-primary-container);
+      border-color: var(--mat-sys-primary);
+      color: var(--mat-sys-on-primary-container);
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.45;
+    }
+
+    > mat-icon:first-child {
+      color: var(--mat-sys-primary);
+    }
+
+    span {
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+    }
+
+    small {
+      margin-top: 2px;
+      color: var(--mat-sys-on-surface-variant);
+      font-size: 11px;
+      line-height: 1.3;
+    }
+
+    .selected-icon {
+      width: 20px;
+      height: 20px;
+      color: var(--mat-sys-primary);
+      font-size: 20px;
+    }
+  }
+
+  .section-toggles {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .fixed-sections-note {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin: 12px 0 0;
+    color: var(--mat-sys-on-surface-variant);
+    font-size: 12px;
+
+    mat-icon {
+      width: 16px;
+      height: 16px;
+      font-size: 16px;
+    }
   }
 }
 
@@ -324,6 +475,121 @@ mat-icon[mat-card-avatar] {
   }
 }
 
+// Recent Activity
+.recent-activity-card {
+  width: 100%;
+
+  mat-icon[mat-card-avatar] {
+    background: var(--mat-sys-secondary-container);
+    color: var(--mat-sys-on-secondary-container);
+  }
+
+  .activity-list {
+    display: flex;
+    flex-direction: column;
+    margin-top: 8px;
+  }
+
+  .activity-row {
+    display: grid;
+    grid-template-columns: 24px minmax(0, 1fr) auto 24px;
+    align-items: center;
+    gap: 12px;
+    min-height: 48px;
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--mat-sys-outline-variant);
+    color: inherit;
+    text-decoration: none;
+
+    &:last-child {
+      border-bottom: 0;
+    }
+
+    &:hover {
+      border-radius: 8px;
+      background: var(--mat-sys-surface-container-high);
+    }
+
+    time {
+      color: var(--mat-sys-on-surface-variant);
+      font-size: 12px;
+    }
+  }
+
+  .activity-copy {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+
+    strong {
+      font-size: 14px;
+      font-weight: 500;
+      text-transform: capitalize;
+    }
+
+    small {
+      overflow: hidden;
+      color: var(--mat-sys-on-surface-variant);
+      font-size: 11px;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+
+  .activity-status {
+    width: 20px;
+    height: 20px;
+    font-size: 20px;
+
+    &.status-active {
+      color: var(--mat-sys-primary);
+    }
+
+    &.status-fetched {
+      color: var(--mat-sys-tertiary);
+    }
+
+    &.status-completed {
+      color: var(--eudiplo-success);
+    }
+
+    &.status-expired {
+      color: var(--eudiplo-warning);
+    }
+
+    &.status-failed {
+      color: var(--eudiplo-danger);
+    }
+  }
+
+  .activity-arrow {
+    color: var(--mat-sys-on-surface-variant);
+  }
+
+  .empty-state {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 20px 8px 8px;
+    color: var(--mat-sys-on-surface-variant);
+
+    > mat-icon {
+      width: 32px;
+      height: 32px;
+      font-size: 32px;
+    }
+
+    strong {
+      color: var(--mat-sys-on-surface);
+    }
+
+    p {
+      margin: 3px 0 0;
+      font-size: 13px;
+    }
+  }
+}
+
 // Quick Actions Card
 .quick-actions-card {
   width: 100%;
@@ -335,6 +601,10 @@ mat-icon[mat-card-avatar] {
 
   .quick-actions {
     padding: 8px 0;
+
+    .focus-first {
+      order: -1;
+    }
 
     a,
     button {
@@ -430,8 +700,40 @@ mat-icon[mat-card-avatar] {
   }
 
   .welcome-header {
+    flex-direction: column !important;
+    align-items: stretch !important;
+    gap: 16px;
+
     h1 {
       font-size: 22px;
+    }
+
+    .header-actions {
+      align-items: stretch;
+      flex-direction: column;
+    }
+
+    .version-chips {
+      flex-wrap: wrap;
+    }
+
+    .customize-button {
+      align-self: flex-start;
+    }
+  }
+
+  .customization-card {
+    .customization-grid,
+    .focus-options {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .recent-activity-card .activity-row {
+    grid-template-columns: 24px minmax(0, 1fr) 24px;
+
+    time {
+      display: none;
     }
   }
 

--- a/apps/client/src/app/dashboard/dashboard.component.ts
+++ b/apps/client/src/app/dashboard/dashboard.component.ts
@@ -18,8 +18,23 @@ import { GrafanaLinkService } from '../services/grafana-link.service';
 import { appControllerGetVersion } from '@eudiplo/sdk-core';
 import { ApiService } from '../core';
 import { MatGridListModule } from '@angular/material/grid-list';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import { DashboardService } from './dashboard.service';
 import { FrontendConfigService } from '../services/frontend-config.service';
+import {
+  DashboardFocus,
+  DashboardPreferences,
+  DashboardPreferencesService,
+  DashboardSection,
+} from './dashboard-preferences.service';
+
+interface DashboardFocusOption {
+  value: DashboardFocus;
+  label: string;
+  description: string;
+  icon: string;
+  available: boolean;
+}
 
 @Component({
   selector: 'app-dashboard',
@@ -36,6 +51,7 @@ import { FrontendConfigService } from '../services/frontend-config.service';
     MatSnackBarModule,
     MatTooltipModule,
     MatGridListModule,
+    MatCheckboxModule,
     DatePipe,
     RouterModule,
   ],
@@ -49,6 +65,16 @@ export class DashboardComponent implements OnInit, OnDestroy {
   backendVersion: string | null = null;
   clientVersion: string | null = null;
   grafanaEnabled = false;
+  customizePanelOpen = false;
+  preferences: DashboardPreferences = {
+    focus: 'balanced',
+    visibleSections: {
+      recentActivity: true,
+      sessionOverview: true,
+      quickActions: true,
+      resources: true,
+    },
+  };
 
   constructor(
     public apiService: ApiService,
@@ -58,10 +84,17 @@ export class DashboardComponent implements OnInit, OnDestroy {
     public frontendConfigService: FrontendConfigService,
     public jwtService: JwtService,
     private readonly router: Router,
-    private readonly snackBar: MatSnackBar
+    private readonly snackBar: MatSnackBar,
+    private readonly dashboardPreferencesService: DashboardPreferencesService
   ) {}
 
   ngOnInit(): void {
+    this.preferences = this.dashboardPreferencesService.load(this.defaultPreferences);
+    if (!this.isFocusAvailable(this.preferences.focus)) {
+      this.preferences = this.defaultPreferences;
+      this.dashboardPreferencesService.save(this.preferences);
+    }
+
     // Check token status periodically (every 30 seconds)
     this.tokenCheckInterval = setInterval(() => {
       this.checkTokenStatus();
@@ -160,5 +193,147 @@ export class DashboardComponent implements OnInit, OnDestroy {
     if (url) {
       window.open(url, '_blank', 'noopener,noreferrer');
     }
+  }
+
+  get focusOptions(): DashboardFocusOption[] {
+    return [
+      {
+        value: 'balanced',
+        label: 'Balanced',
+        description: 'A broad view across configuration and operations',
+        icon: 'dashboard',
+        available: true,
+      },
+      {
+        value: 'issuance',
+        label: 'Issuance',
+        description: 'Prioritize credential issuance workflows',
+        icon: 'card_giftcard',
+        available:
+          this.dashboardService.canManageIssuance || this.jwtService.hasRole('issuance:offer'),
+      },
+      {
+        value: 'verification',
+        label: 'Verification',
+        description: 'Prioritize presentation requests and verification',
+        icon: 'fact_check',
+        available:
+          this.dashboardService.canManagePresentation ||
+          this.jwtService.hasRole('presentation:request'),
+      },
+      {
+        value: 'operations',
+        label: 'Operations',
+        description: 'Focus on health, sessions, and recent activity',
+        icon: 'monitor_heart',
+        available: this.dashboardService.canViewSessions,
+      },
+    ];
+  }
+
+  get focusLabel(): string {
+    return this.focusOptions.find((option) => option.value === this.preferences.focus)?.label ?? '';
+  }
+
+  get readinessTitle(): string {
+    if (this.dashboardService.isLoading) return 'Checking system readiness…';
+    if (this.dashboardService.hasWarnings) {
+      const count = this.dashboardService.warningMessages.length;
+      return `${count} ${count === 1 ? 'item needs' : 'items need'} attention`;
+    }
+    if (this.dashboardService.isReadOnly) return 'Monitoring access';
+    if (this.dashboardService.isSetupComplete) return 'Ready for wallet flows';
+    return 'Setup incomplete';
+  }
+
+  get defaultPreferences(): DashboardPreferences {
+    let focus: DashboardFocus = 'balanced';
+    if (
+      (this.dashboardService.canManageIssuance || this.jwtService.hasRole('issuance:offer')) &&
+      !this.dashboardService.canManagePresentation &&
+      !this.jwtService.hasRole('presentation:request')
+    ) {
+      focus = 'issuance';
+    } else if (
+      (this.dashboardService.canManagePresentation ||
+        this.jwtService.hasRole('presentation:request')) &&
+      !this.dashboardService.canManageIssuance &&
+      !this.jwtService.hasRole('issuance:offer')
+    ) {
+      focus = 'verification';
+    } else if (
+      this.dashboardService.canViewSessions &&
+      !this.dashboardService.canManageIssuance &&
+      !this.dashboardService.canManagePresentation
+    ) {
+      focus = 'operations';
+    }
+
+    return this.preferencesForFocus(focus);
+  }
+
+  isSectionVisible(section: DashboardSection): boolean {
+    return this.preferences.visibleSections[section];
+  }
+
+  setFocus(focus: DashboardFocus): void {
+    if (!this.isFocusAvailable(focus)) return;
+    this.preferences = this.preferencesForFocus(focus);
+    this.persistPreferences();
+  }
+
+  setSectionVisibility(section: DashboardSection, visible: boolean): void {
+    this.preferences = {
+      ...this.preferences,
+      visibleSections: { ...this.preferences.visibleSections, [section]: visible },
+    };
+    this.persistPreferences();
+  }
+
+  resetDashboard(): void {
+    this.dashboardPreferencesService.reset();
+    this.preferences = this.defaultPreferences;
+    this.customizePanelOpen = false;
+    this.snackBar.open('Dashboard reset to your role-based defaults.', 'Close', {
+      duration: 3000,
+    });
+  }
+
+  sessionStatusIcon(status: string): string {
+    switch (status) {
+      case 'completed':
+        return 'check_circle';
+      case 'failed':
+        return 'error';
+      case 'expired':
+        return 'schedule';
+      case 'fetched':
+        return 'download';
+      default:
+        return 'hourglass_empty';
+    }
+  }
+
+  private persistPreferences(): void {
+    this.dashboardPreferencesService.save(this.preferences);
+  }
+
+  private preferencesForFocus(focus: DashboardFocus): DashboardPreferences {
+    const visibleSections: Record<DashboardSection, boolean> = {
+      recentActivity: true,
+      sessionOverview: true,
+      quickActions: true,
+      resources: focus === 'balanced',
+    };
+
+    if (focus === 'operations') {
+      visibleSections.quickActions = false;
+    }
+
+    return { focus, visibleSections };
+  }
+
+  private isFocusAvailable(focus: DashboardFocus): boolean {
+    return this.focusOptions.some((option) => option.value === focus && option.available);
   }
 }

--- a/apps/client/src/app/dashboard/dashboard.service.ts
+++ b/apps/client/src/app/dashboard/dashboard.service.ts
@@ -40,6 +40,7 @@ export class DashboardService {
   lastSuccessfulIssuanceAt: string | null = null;
   lastSuccessfulPresentationAt: string | null = null;
   hasIssuanceConfig = false;
+  recentSessions: Session[] = [];
   isLoading = true;
 
   constructor(private readonly jwtService: JwtService) {}
@@ -67,6 +68,7 @@ export class DashboardService {
     this.credentialConfigs = 0;
     this.presentationConfigs = 0;
     this.hasIssuanceConfig = false;
+    this.recentSessions = [];
 
     try {
       // Build list of promises based on user roles
@@ -128,6 +130,12 @@ export class DashboardService {
               this.presentationConfigs = result.value.data.length;
               break;
             case 'sessions':
+              this.recentSessions = [...result.value.data.items]
+                .sort(
+                  (left: Session, right: Session) =>
+                    new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime()
+                )
+                .slice(0, 5);
               result.value.data.items.forEach((session: Session) => {
                 switch (session.status) {
                   case 'active':
@@ -211,6 +219,16 @@ export class DashboardService {
   get canViewSessions(): boolean {
     return (
       this.jwtService.hasRole('issuance:offer') || this.jwtService.hasRole('presentation:request')
+    );
+  }
+
+  get totalSessions(): number {
+    return (
+      this.sessionActive +
+      this.sessionCompleted +
+      this.sessionFetched +
+      this.sessionFailed +
+      this.sessionExpired
     );
   }
 


### PR DESCRIPTION
## Summary

- add role-aware dashboard focus presets for balanced, issuance, verification, and operations workflows
- let users show or hide secondary dashboard sections while keeping health and warnings fixed
- persist preferences per user and tenant, with a reset to role-based defaults
- add recent session activity and include failed and expired sessions in the total
- improve dashboard readiness messaging and responsive layout

## Validation

- pnpm --filter @eudiplo/client build
- pnpm --filter @eudiplo/client lint
- pnpm --filter @eudiplo/client exec vitest run src/app/dashboard/dashboard-preferences.service.spec.ts --environment jsdom --globals (4 tests passed)

## Test-suite note

The full Angular test target currently has unrelated existing compilation failures in app.component.spec.ts and issuance-offer specs due to Jasmine/Vitest API mismatches.