### PR TITLE
Fix OID4VP ephemeral encryption key lifecycle

### DIFF
--- a/apps/backend/src/crypto/key/key-chain.controller.ts
+++ b/apps/backend/src/crypto/key/key-chain.controller.ts
@@ -145,10 +145,12 @@ export class KeyChainController {
     }
 
     /**
-     * List all key chains for the tenant.
+     * List user-manageable signing key chains for the tenant.
      */
     @Get()
-    @ApiOperation({ summary: "List all key chains for the tenant" })
+    @ApiOperation({
+        summary: "List user-manageable signing key chains for the tenant",
+    })
     @ApiResponse({
         status: 200,
         description: "List of key chains",

--- a/apps/backend/src/crypto/key/key-chain.service.ts
+++ b/apps/backend/src/crypto/key/key-chain.service.ts
@@ -267,7 +267,14 @@ export class KeyChainService {
         usageType?: KeyUsageType,
     ): Promise<KeyChainResponseDto[]> {
         const keyChains = await this.keyChainRepository.find({
-            where: { tenantId, ...(usageType ? { usageType } : {}) },
+            // Only signing key chains are user-manageable. Tenant-wide
+            // encryption material is system-owned and must not be exposed in
+            // the key-management list.
+            where: {
+                tenantId,
+                usage: KeyUsage.Sign,
+                ...(usageType ? { usageType } : {}),
+            },
         });
 
         return keyChains.map((kc) => this.toResponseDto(kc));

--- a/apps/backend/src/session/entities/session.entity.ts
+++ b/apps/backend/src/session/entities/session.entity.ts
@@ -206,7 +206,7 @@ export class Session {
      * wallet responses. Encrypted at rest.
      */
     @Column("text", { nullable: true, transformer: EncryptedJsonTransformer })
-    responseEncryptionPrivateJwk?: JWK;
+    responseEncryptionPrivateJwk?: JWK | null;
 
     /**
      * Verified credentials from the presentation process.

--- a/apps/backend/src/session/session.service.spec.ts
+++ b/apps/backend/src/session/session.service.spec.ts
@@ -5,6 +5,7 @@ import { SchedulerRegistry } from "@nestjs/schedule";
 import { MetricService } from "nestjs-otel";
 import { Repository } from "typeorm";
 import { describe, expect, test, vi } from "vitest";
+import { SessionCleanupMode } from "../auth/tenant/entities/session-storage-config";
 import { TenantEntity } from "../auth/tenant/entities/tenant.entity";
 import { Session, SessionStatus } from "./entities/session.entity";
 import { SessionService } from "./session.service";
@@ -56,11 +57,17 @@ describe("SessionService", () => {
         expect(sessionRepository.update).toHaveBeenCalledTimes(2);
         expect(sessionRepository.update).toHaveBeenCalledWith(
             { id: "active-session" },
-            { status: SessionStatus.Expired },
+            {
+                status: SessionStatus.Expired,
+                responseEncryptionPrivateJwk: null,
+            },
         );
         expect(sessionRepository.update).toHaveBeenCalledWith(
             { id: "fetched-session" },
-            { status: SessionStatus.Expired },
+            {
+                status: SessionStatus.Expired,
+                responseEncryptionPrivateJwk: null,
+            },
         );
         expect(eventEmitter.emit).toHaveBeenCalledTimes(2);
         expect(eventEmitter.emit).toHaveBeenCalledWith(
@@ -77,5 +84,107 @@ describe("SessionService", () => {
                 status: SessionStatus.Expired,
             }),
         );
+    });
+
+    test.each([
+        SessionStatus.Completed,
+        SessionStatus.Failed,
+        SessionStatus.Expired,
+    ])(
+        "clears the response encryption key when a session becomes %s",
+        async (status) => {
+            const sessionRepository = {
+                update: vi.fn().mockResolvedValue({ affected: 1 }),
+            } as unknown as Repository<Session>;
+            const tenantRepository = {
+                find: vi.fn().mockResolvedValue([]),
+            } as unknown as Repository<TenantEntity>;
+            const service = new SessionService(
+                sessionRepository,
+                tenantRepository,
+                {} as ConfigService,
+                {} as SchedulerRegistry,
+                { emit: vi.fn() } as unknown as EventEmitter2,
+                {
+                    getUpDownCounter: vi.fn().mockReturnValue({ add: vi.fn() }),
+                } as unknown as MetricService,
+            );
+            const session = {
+                id: "session-1",
+                tenantId: "tenant-1",
+                status: SessionStatus.Active,
+            } as Session;
+
+            await service.setState(session, status);
+
+            expect(sessionRepository.update).toHaveBeenCalledWith(
+                { id: session.id },
+                {
+                    status,
+                    responseEncryptionPrivateJwk: null,
+                },
+            );
+        },
+    );
+
+    test("anonymizes sensitive session fields with database NULL values", async () => {
+        const queryBuilder = {
+            update: vi.fn(),
+            delete: vi.fn(),
+            set: vi.fn(),
+            where: vi.fn(),
+            andWhere: vi.fn(),
+            execute: vi.fn().mockResolvedValue({ affected: 1 }),
+        };
+        queryBuilder.update.mockReturnValue(queryBuilder);
+        queryBuilder.delete.mockReturnValue(queryBuilder);
+        queryBuilder.set.mockReturnValue(queryBuilder);
+        queryBuilder.where.mockReturnValue(queryBuilder);
+        queryBuilder.andWhere.mockReturnValue(queryBuilder);
+
+        const sessionRepository = {
+            findBy: vi.fn().mockResolvedValue([]),
+            createQueryBuilder: vi.fn().mockReturnValue(queryBuilder),
+        } as unknown as Repository<Session>;
+        const tenantRepository = {
+            find: vi.fn().mockResolvedValue([
+                {
+                    id: "tenant-1",
+                    sessionConfig: {
+                        cleanupMode: SessionCleanupMode.Anonymize,
+                        ttlSeconds: 3600,
+                    },
+                },
+            ]),
+        } as unknown as Repository<TenantEntity>;
+        const service = new SessionService(
+            sessionRepository,
+            tenantRepository,
+            {
+                getOrThrow: vi.fn((key: string) =>
+                    key === "SESSION_TTL" ? 3600 : "full",
+                ),
+            } as unknown as ConfigService,
+            {} as SchedulerRegistry,
+            { emit: vi.fn() } as unknown as EventEmitter2,
+            {
+                getUpDownCounter: vi.fn().mockReturnValue({ add: vi.fn() }),
+            } as unknown as MetricService,
+        );
+
+        await service.tidyUpSessions();
+
+        const sensitiveValues = queryBuilder.set.mock.calls[0][0];
+        expect(Object.keys(sensitiveValues)).toEqual([
+            "credentials",
+            "credentialPayload",
+            "auth_queries",
+            "offer",
+            "requestObject",
+            "responseEncryptionPrivateJwk",
+        ]);
+        for (const value of Object.values(sensitiveValues)) {
+            expect(value()).toBe("NULL");
+        }
     });
 });

--- a/apps/backend/src/session/session.service.ts
+++ b/apps/backend/src/session/session.service.ts
@@ -128,15 +128,33 @@ export class SessionService implements OnApplicationBootstrap {
      */
     async setState(session: Session, status: SessionStatus) {
         const sessionType = session.requestId ? "verification" : "issuance";
+        const isTerminal =
+            status === SessionStatus.Completed ||
+            status === SessionStatus.Failed ||
+            status === SessionStatus.Expired;
 
-        await this.sessionRepository.update({ id: session.id }, { status });
+        await this.sessionRepository.update(
+            { id: session.id },
+            {
+                status,
+                ...(isTerminal
+                    ? { responseEncryptionPrivateJwk: null }
+                    : {}),
+            },
+        );
 
         // Emit status change event for SSE subscribers
         const event: SessionStatusChangedEvent = {
             sessionId: session.id,
             status,
             updatedAt: new Date(),
-            session: { ...session, status },
+            session: {
+                ...session,
+                status,
+                ...(isTerminal
+                    ? { responseEncryptionPrivateJwk: null }
+                    : {}),
+            },
         };
         this.eventEmitter.emit(SESSION_STATUS_CHANGED, event);
 
@@ -350,12 +368,12 @@ export class SessionService implements OnApplicationBootstrap {
                 .createQueryBuilder()
                 .update()
                 .set({
-                    credentials: undefined,
-                    credentialPayload: undefined,
-                    auth_queries: undefined,
-                    offer: undefined,
-                    requestObject: undefined,
-                    responseEncryptionPrivateJwk: undefined,
+                    credentials: () => "NULL",
+                    credentialPayload: () => "NULL",
+                    auth_queries: () => "NULL",
+                    offer: () => "NULL",
+                    requestObject: () => "NULL",
+                    responseEncryptionPrivateJwk: () => "NULL",
                 })
                 .where("tenantId = :tenantId", { tenantId: tenant.id })
                 .andWhere("createdAt < :cutoffDate", { cutoffDate })

--- a/apps/backend/src/session/session.service.ts
+++ b/apps/backend/src/session/session.service.ts
@@ -137,9 +137,7 @@ export class SessionService implements OnApplicationBootstrap {
             { id: session.id },
             {
                 status,
-                ...(isTerminal
-                    ? { responseEncryptionPrivateJwk: null }
-                    : {}),
+                ...(isTerminal ? { responseEncryptionPrivateJwk: null } : {}),
             },
         );
 
@@ -151,9 +149,7 @@ export class SessionService implements OnApplicationBootstrap {
             session: {
                 ...session,
                 status,
-                ...(isTerminal
-                    ? { responseEncryptionPrivateJwk: null }
-                    : {}),
+                ...(isTerminal ? { responseEncryptionPrivateJwk: null } : {}),
             },
         };
         this.eventEmitter.emit(SESSION_STATUS_CHANGED, event);

--- a/apps/backend/src/verifier/oid4vp/oid4vp.service.ts
+++ b/apps/backend/src/verifier/oid4vp/oid4vp.service.ts
@@ -572,6 +572,7 @@ export class Oid4vpService {
             await this.sessionService.add(session.id, {
                 status: SessionStatus.Failed,
                 errorReason: `Wallet error: ${errorMessage}`,
+                responseEncryptionPrivateJwk: null,
             });
 
             // Return redirect_uri with error if configured
@@ -690,6 +691,9 @@ export class Oid4vpService {
                 responseCode,
                 consumed: true,
                 consumedAt: new Date(),
+                // The response key is unique to this authorization request and
+                // is no longer needed after the response has been processed.
+                responseEncryptionPrivateJwk: null,
                 // Per-credential provenance for the OID4VP path is threaded in a
                 // follow-up (see finding 2026-07-21-structured-session-outcome,
                 // Phase 2); record the success result for now.
@@ -796,6 +800,7 @@ export class Oid4vpService {
             await this.sessionService.add(session.id, {
                 status: SessionStatus.Failed,
                 errorReason: errorMessage,
+                responseEncryptionPrivateJwk: null,
                 ...(structured?.code
                     ? {
                           failureCode: structured.code,

--- a/apps/backend/test/key/key-import.e2e-spec.ts
+++ b/apps/backend/test/key/key-import.e2e-spec.ts
@@ -67,5 +67,10 @@ describe("Key Chain — Import (e2e)", () => {
             (keyChain) => keyChain.id === keyId,
         );
         expect(foundKeyChain).toBeDefined();
+        expect(
+            getResponse.body.some(
+                (keyChain) => keyChain.usageType === KeyUsageType.Encrypt,
+            ),
+        ).toBe(false);
     });
 });

--- a/apps/backend/test/presentation/presentation-sdjwt.e2e-spec.ts
+++ b/apps/backend/test/presentation/presentation-sdjwt.e2e-spec.ts
@@ -139,7 +139,7 @@ describe("Presentation - SD-JWT Credential", () => {
     });
 
     test("present sd jwt credential", async () => {
-        const { submitRes } = await submitPresentation({
+        const { res, submitRes } = await submitPresentation({
             requestId: "pid-no-hook",
             credentialId: "pid",
             privateKey: privateIssuerKey,
@@ -148,6 +148,13 @@ describe("Presentation - SD-JWT Credential", () => {
 
         expect(submitRes).toBeDefined();
         expect(submitRes.response.status).toBe(200);
+
+        const sessionResponse = await request(app.getHttpServer())
+            .get(`/session/${res.body.session}`)
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .expect(200);
+        expect(sessionResponse.body.responseEncryptionPrivateJwk).toBeNull();
     });
 
     test("present sd jwt credential using claim_sets preference order", async () => {

--- a/apps/client/src/app/key-management/key-management-list/key-management-list.component.html
+++ b/apps/client/src/app/key-management/key-management-list/key-management-list.component.html
@@ -20,7 +20,6 @@
         <mat-option value="access">Access Certificate</mat-option>
         <mat-option value="statusList">Status List</mat-option>
         <mat-option value="trustList">Trust List</mat-option>
-        <mat-option value="encrypt">Encryption</mat-option>
       </mat-select>
     </mat-form-field>
 

--- a/apps/client/src/app/key-management/key-management-list/key-management-list.component.ts
+++ b/apps/client/src/app/key-management/key-management-list/key-management-list.component.ts
@@ -14,7 +14,7 @@ import { KeyChainResponseDto } from '@eudiplo/sdk-core';
 import { KeyChainService } from '../key-chain.service';
 import { ConfigOwnershipDirective } from '../../config-portability/config-ownership.directive';
 
-type KeyUsageType = 'attestation' | 'statusList' | 'access' | 'trustList' | 'encrypt';
+type KeyUsageType = 'attestation' | 'statusList' | 'access' | 'trustList';
 
 /**
  * Display item for key chains.
@@ -92,11 +92,6 @@ export class KeyManagementListComponent implements OnInit {
       label: 'Trust List Keys',
       icon: 'shield',
       description: 'Keys for signing trust list entries.',
-    },
-    encrypt: {
-      label: 'Encryption Keys',
-      icon: 'lock',
-      description: 'Keys for encryption use cases.',
     },
   };
 


### PR DESCRIPTION
## 📝 Description

Clear per-request OID4VP response-encryption private keys once a presentation session reaches a terminal state, expires, or is anonymized. Keep system-owned encryption chains out of the user-manageable key-chain API and UI.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test improvements
- [ ] 🏗️ Build/CI changes

## 💥 Breaking Changes (if applicable)

None.

## 🧪 Testing

- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] E2E tests pass
- [ ] Manual testing performed

**Test Configuration**:

- OS: macOS
- Test environment: local
- `apps/backend/src/session/session.service.spec.ts` (5 tests)
- `pnpm exec biome check apps/backend/src/session/session.service.spec.ts`
- Commit hooks: backend/client format, workspace lint, Knip

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 📋 Additional Notes

The ephemeral private JWK remains encrypted at rest while the request is active and is never persisted as a key-chain record.