### PR TITLE
fix(backend): update root endpoint documentation url and add response dto

### DIFF
--- a/apps/backend/src/core/app/app.controller.ts
+++ b/apps/backend/src/core/app/app.controller.ts
@@ -9,6 +9,7 @@ import {
 import { JwtAuthGuard } from "../../auth/auth.guard";
 import { ConfigImportModeService } from "../../platform/config-import/config-import-mode.service";
 import { FrontendConfigResponseDto } from "./dto/frontend-config-response.dto";
+import { ServiceInfoResponseDto } from "./dto/service-info-response.dto";
 import { VersionResponseDto } from "./dto/version-response.dto";
 
 /**
@@ -26,11 +27,16 @@ export class AppController {
      * Main endpoint providing service info
      */
     @Get()
-    main() {
+    @ApiOperation({ summary: "Get service info" })
+    @ApiResponse({
+        status: 200,
+        description: "Service info",
+        type: ServiceInfoResponseDto,
+    })
+    main(): ServiceInfoResponseDto {
         return {
             service: "EUDIPLO",
-            documentation:
-                "https://openwallet-foundation.github.io/eudiplo/docs/latest/",
+            documentation: "https://docs.eudiplo.dev",
         };
     }
 

--- a/apps/backend/src/core/app/dto/service-info-response.dto.ts
+++ b/apps/backend/src/core/app/dto/service-info-response.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class ServiceInfoResponseDto {
+    @ApiProperty({
+        description: "Service name",
+        example: "EUDIPLO",
+    })
+    service!: string;
+
+    @ApiProperty({
+        description: "Documentation URL",
+        example: "https://docs.eudiplo.dev",
+    })
+    documentation!: string;
+}


### PR DESCRIPTION
## 📝 Description

Updates the documentation URL returned by the root `GET /` endpoint to `https://docs.eudiplo.dev`. In addition, adds Swagger OpenAPI annotations (`@ApiOperation`, `@ApiResponse`) and a dedicated `ServiceInfoResponseDto` to adhere to NestJS architectural guidelines and DTO conventions.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements
- [ ] 🏗️ Build/CI changes

## 💥 Breaking Changes (if applicable)

None.

## 🧪 Testing

- [x] Unit tests pass
- [x] Integration tests pass
- [x] E2E tests pass
- [x] Manual testing performed