### PR TITLE
docs: clarify commit signing and DCO sign-off rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -89,7 +89,12 @@
 - Use **conventional commits** (`feat:`, `fix:`, `docs:`, etc.). Semantic-release uses these to determine version bumps.
 - **Breaking changes**: Add a `BREAKING CHANGE:` footer in the commit message body **and** fill in the "Breaking Changes" section of the PR description. The PR description is the primary source for generating migration guides — describe _what_ changed and _how to migrate_.
 - When creating a PR that contains breaking changes, add the `breaking-change` label.
-- **All commits must be signed** to pass GitHub's verification checks. Configure GPG signing locally (`git config --global user.signingkey <key>`) and use `-S` flag when committing (`git commit -S`) or enable auto-signing (`git config --global commit.gpgsign true`).
+- Every commit must be cryptographically signed and include a DCO sign-off.
+- Use `git commit -S -s` when creating commits, including amended commits.
+- Use the existing Git signing configuration and configured user identity.
+  Do not change the signing key, signing format, or signing program.
+- If signing fails or requires 1Password authorization, report the error
+  and let the user authorize it. Never bypass signing.
 
 ## Deployment Conventions
 - Docker Compose files: root `docker-compose.yml` and `deployment/docker-compose/docker-compose.yml`.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -133,5 +133,6 @@
   "sonarlint.connectedMode.project": {
     "connectionId": "eudiplo",
     "projectKey": "openwallet-foundation_eudiplo"
-  }
+  },
+  "git.alwaysSignOff": true
 }


### PR DESCRIPTION
## 📝 Description

Updates the Copilot instructions for commit signing so that agent-created commits are both cryptographically signed and DCO signed off, using the developer's existing Git signing configuration.

- Replaces the GPG-specific guidance with tool-agnostic rules (`git commit -S -s`)
- Explicitly forbids changing the signing key, signing format, or signing program
- Requires reporting signing failures (e.g. 1Password authorization prompts) instead of bypassing signing
- Enables `git.alwaysSignOff` in the workspace VS Code settings

## 🔄 Type of Change

- [x] 📚 Documentation update

## 💥 Breaking Changes (if applicable)

None.

## 🧪 Testing

- [x] Manual testing performed — this PR's own commit was created with `git commit -S -s` and carries both an SSH signature and a `Signed-off-by` trailer.

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## 📋 Additional Notes

No code changes — documentation and editor settings only.
