### PR TITLE
feat(oid4vci): evaluate and implement caching for AS metadata and trust checks

### DIFF
--- a/apps/backend/src/issuer/issuance/oid4vci/authorization/chained-as/chained-as.service.spec.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/authorization/chained-as/chained-as.service.spec.ts
@@ -1,0 +1,128 @@
+import { HttpService } from "@nestjs/axios";
+import type { MetricService } from "nestjs-otel";
+import { of, throwError } from "rxjs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChainedAsService } from "./chained-as.service";
+
+describe("ChainedAsService upstream discovery caching & deduplication", () => {
+    let service: ChainedAsService;
+    let httpService: HttpService;
+    let metricService: MetricService;
+    const addCounterMock = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        httpService = {
+            get: vi.fn(),
+        } as unknown as HttpService;
+
+        metricService = {
+            getCounter: vi.fn(() => ({
+                add: addCounterMock,
+            })),
+        } as unknown as MetricService;
+
+        service = Object.assign(
+            Object.create(ChainedAsService.prototype) as ChainedAsService,
+            {
+                httpService,
+                metricService,
+                discoveryCache: new Map(),
+                inFlightDiscoveryRequests: new Map(),
+                logger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+                issuanceService: {
+                    getIssuanceConfiguration: vi.fn().mockResolvedValue({}),
+                },
+                assertFederationTrustForUpstreamIssuer: vi.fn().mockResolvedValue(undefined),
+                discoveryHitsCounter: metricService.getCounter(),
+                discoveryMissesCounter: metricService.getCounter(),
+                discoveryStaleCounter: metricService.getCounter(),
+                discoveryFetchesCounter: metricService.getCounter(),
+            },
+        );
+    });
+
+    it("fetches upstream OIDC discovery and caches the result", async () => {
+        vi.spyOn(httpService, "get").mockReturnValue(
+            of({
+                data: {
+                    issuer: "https://upstream.example.org",
+                    authorization_endpoint: "https://upstream.example.org/auth",
+                },
+            } as any),
+        );
+
+        const doc1 = await service.getUpstreamDiscovery(
+            "tenant-1",
+            "https://upstream.example.org",
+        );
+
+        expect(doc1.issuer).toBe("https://upstream.example.org");
+        expect(httpService.get).toHaveBeenCalledTimes(1);
+
+        // Second call hits cache
+        const doc2 = await service.getUpstreamDiscovery(
+            "tenant-1",
+            "https://upstream.example.org",
+        );
+
+        expect(doc2.issuer).toBe("https://upstream.example.org");
+        expect(httpService.get).toHaveBeenCalledTimes(1);
+    });
+
+    it("deduplicates concurrent in-flight discovery requests", async () => {
+        vi.spyOn(httpService, "get").mockReturnValue(
+            of({
+                data: {
+                    issuer: "https://upstream.example.org",
+                    authorization_endpoint: "https://upstream.example.org/auth",
+                },
+            } as any),
+        );
+
+        const [d1, d2, d3] = await Promise.all([
+            service.getUpstreamDiscovery("tenant-1", "https://upstream.example.org"),
+            service.getUpstreamDiscovery("tenant-1", "https://upstream.example.org"),
+            service.getUpstreamDiscovery("tenant-1", "https://upstream.example.org"),
+        ]);
+
+        expect(d1.issuer).toBe("https://upstream.example.org");
+        expect(d2.issuer).toBe("https://upstream.example.org");
+        expect(d3.issuer).toBe("https://upstream.example.org");
+        expect(httpService.get).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns stale cached discovery document if re-fetch fails", async () => {
+        vi.spyOn(httpService, "get")
+            .mockReturnValueOnce(
+                of({
+                    data: {
+                        issuer: "https://upstream.example.org",
+                        authorization_endpoint: "https://upstream.example.org/auth",
+                    },
+                } as any),
+            )
+            .mockReturnValueOnce(
+                throwError(() => new Error("Network unreachable")),
+            );
+
+        // First fetch -> populates cache
+        await service.getUpstreamDiscovery("tenant-1", "https://upstream.example.org");
+
+        // Expire the item
+        const cached = (service as any).discoveryCache.get("https://upstream.example.org");
+        cached.expiresAt = Date.now() - 1000;
+
+        // Second fetch -> fresh fetch fails, return stale doc
+        const staleDoc = await service.getUpstreamDiscovery(
+            "tenant-1",
+            "https://upstream.example.org",
+        );
+
+        expect(staleDoc.issuer).toBe("https://upstream.example.org");
+        expect(httpService.get).toHaveBeenCalledTimes(2);
+        expect((service as any).logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining("returning stale discovery document"),
+        );
+    });
+});

--- a/apps/backend/src/issuer/issuance/oid4vci/authorization/chained-as/chained-as.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/authorization/chained-as/chained-as.service.ts
@@ -5,11 +5,12 @@ import {
     Injectable,
     Logger,
     NotFoundException,
+    Optional,
 } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { InjectRepository } from "@nestjs/typeorm";
 import { decodeJwt } from "jose";
-import { TraceService } from "nestjs-otel";
+import { MetricService, TraceService } from "nestjs-otel";
 import { firstValueFrom } from "rxjs";
 import { LessThan, Repository } from "typeorm";
 import { v4 } from "uuid";
@@ -70,8 +71,22 @@ export class ChainedAsService {
     /** Cache for upstream OIDC discovery documents */
     private readonly discoveryCache = new Map<
         string,
-        { doc: OidcDiscoveryDocument; expiresAt: number }
+        { doc: OidcDiscoveryDocument; fetchedAt: number; expiresAt: number }
     >();
+    private readonly inFlightDiscoveryRequests = new Map<
+        string,
+        Promise<OidcDiscoveryDocument>
+    >();
+
+    private readonly discoveryHitsCounter;
+    private readonly discoveryMissesCounter;
+    private readonly discoveryStaleCounter;
+    private readonly discoveryFetchesCounter;
+
+    clearDiscoveryCache(): void {
+        this.discoveryCache.clear();
+        this.inFlightDiscoveryRequests.clear();
+    }
 
     /** Request URI prefix for PAR responses */
     private readonly REQUEST_URI_PREFIX = "urn:ietf:params:oauth:request_uri:";
@@ -93,7 +108,25 @@ export class ChainedAsService {
         private readonly traceService: TraceService,
         @InjectRepository(ChainedAsSessionEntity)
         private readonly sessionRepository: Repository<ChainedAsSessionEntity>,
-    ) {}
+        @Optional() private readonly metricService?: MetricService,
+    ) {
+        this.discoveryHitsCounter = this.metricService?.getCounter(
+            "chained_as_discovery_cache_hits_total",
+            { description: "Total hits on Chained AS upstream discovery cache" },
+        );
+        this.discoveryMissesCounter = this.metricService?.getCounter(
+            "chained_as_discovery_cache_misses_total",
+            { description: "Total misses on Chained AS upstream discovery cache" },
+        );
+        this.discoveryStaleCounter = this.metricService?.getCounter(
+            "chained_as_discovery_cache_stale_total",
+            { description: "Total stale hits on Chained AS upstream discovery cache" },
+        );
+        this.discoveryFetchesCounter = this.metricService?.getCounter(
+            "chained_as_discovery_fetches_total",
+            { description: "Total outbound Chained AS upstream discovery fetches" },
+        );
+    }
 
     /**
      * Get the base URL for this tenant's Chained AS.
@@ -176,34 +209,66 @@ export class ChainedAsService {
             federationTrustSource,
         );
 
+        const now = Date.now();
         const cached = this.discoveryCache.get(issuer);
-        if (cached && cached.expiresAt > Date.now()) {
+        if (cached && cached.expiresAt > now) {
+            this.discoveryHitsCounter?.add(1, { issuer });
+            this.logger.debug(`OIDC discovery cache hit for ${issuer}`);
             return cached.doc;
         }
 
-        const wellKnownUrl = `${issuer.replace(/\/$/, "")}/.well-known/openid-configuration`;
+        const inFlight = this.inFlightDiscoveryRequests.get(issuer);
+        if (inFlight) {
+            this.logger.debug(
+                `Deduplicating in-flight OIDC discovery fetch for ${issuer}`,
+            );
+            return inFlight;
+        }
+
+        this.discoveryMissesCounter?.add(1, { issuer });
+
+        const fetchPromise = (async (): Promise<OidcDiscoveryDocument> => {
+            const wellKnownUrl = `${issuer.replace(/\/$/, "")}/.well-known/openid-configuration`;
+            this.discoveryFetchesCounter?.add(1, { issuer });
+
+            try {
+                const response = await firstValueFrom(
+                    this.httpService.get<OidcDiscoveryDocument>(wellKnownUrl),
+                );
+
+                const doc = response.data;
+                // Cache for 5 minutes
+                this.discoveryCache.set(issuer, {
+                    doc,
+                    fetchedAt: Date.now(),
+                    expiresAt: Date.now() + 5 * 60 * 1000,
+                });
+
+                return doc;
+            } catch (error) {
+                if (cached && now - cached.fetchedAt <= 60 * 60 * 1000) {
+                    this.discoveryStaleCounter?.add(1, { issuer });
+                    this.logger.warn(
+                        `Failed to fetch OIDC discovery from ${wellKnownUrl}, returning stale discovery document: ${String(error)}`,
+                    );
+                    return cached.doc;
+                }
+                this.logger.error(
+                    `Failed to fetch OIDC discovery from ${wellKnownUrl}`,
+                    error,
+                );
+                throw new BadRequestException(
+                    "Failed to fetch upstream OIDC configuration",
+                );
+            }
+        })();
+
+        this.inFlightDiscoveryRequests.set(issuer, fetchPromise);
 
         try {
-            const response = await firstValueFrom(
-                this.httpService.get<OidcDiscoveryDocument>(wellKnownUrl),
-            );
-
-            const doc = response.data;
-            // Cache for 5 minutes
-            this.discoveryCache.set(issuer, {
-                doc,
-                expiresAt: Date.now() + 5 * 60 * 1000,
-            });
-
-            return doc;
-        } catch (error) {
-            this.logger.error(
-                `Failed to fetch OIDC discovery from ${wellKnownUrl}`,
-                error,
-            );
-            throw new BadRequestException(
-                "Failed to fetch upstream OIDC configuration",
-            );
+            return await fetchPromise;
+        } finally {
+            this.inFlightDiscoveryRequests.delete(issuer);
         }
     }
 

--- a/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.spec.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.spec.ts
@@ -1,4 +1,5 @@
 import type { AuthorizationServerMetadata } from "@openid4vc/oauth2";
+import { of, throwError } from "rxjs";
 import { describe, expect, it, vi } from "vitest";
 import { Oid4vciService } from "./oid4vci.service";
 
@@ -47,6 +48,101 @@ describe("Oid4vciService internal JWKS resolution", () => {
         ]);
         expect(authorizationServers[0].jwks_uri).toBe(
             "https://issuer.example/.well-known/jwks.json/issuers/acme",
+        );
+    });
+});
+
+describe("Oid4vciService authorization server metadata caching & deduplication", () => {
+    it("caches AS metadata and deduplicates concurrent in-flight requests", async () => {
+        const httpGetMock = vi.fn().mockReturnValue(
+            of({
+                data: {
+                    issuer: "https://as.example.org",
+                    token_endpoint: "https://as.example.org/token",
+                },
+            }),
+        );
+        const addCounterMock = vi.fn();
+        const metricServiceMock = {
+            getCounter: vi.fn(() => ({
+                add: addCounterMock,
+            })),
+        };
+
+        const service = Object.assign(
+            Object.create(Oid4vciService.prototype) as Oid4vciService,
+            {
+                httpService: { get: httpGetMock },
+                asMetadataCache: new Map(),
+                inFlightAsMetadataRequests: new Map(),
+                logger: { debug: vi.fn(), warn: vi.fn() },
+                asMetadataHitsCounter: metricServiceMock.getCounter(),
+                asMetadataMissesCounter: metricServiceMock.getCounter(),
+                asMetadataStaleCounter: metricServiceMock.getCounter(),
+                asMetadataFetchesCounter: metricServiceMock.getCounter(),
+            },
+        );
+
+        const [m1, m2, m3] = await Promise.all([
+            service["fetchAuthorizationServerMetadata"]("https://as.example.org"),
+            service["fetchAuthorizationServerMetadata"]("https://as.example.org"),
+            service["fetchAuthorizationServerMetadata"]("https://as.example.org"),
+        ]);
+
+        expect(m1.issuer).toBe("https://as.example.org");
+        expect(m2.issuer).toBe("https://as.example.org");
+        expect(m3.issuer).toBe("https://as.example.org");
+        expect(httpGetMock).toHaveBeenCalledTimes(1);
+
+        // Next call hits cache
+        const m4 = await service["fetchAuthorizationServerMetadata"](
+            "https://as.example.org",
+        );
+        expect(m4.issuer).toBe("https://as.example.org");
+        expect(httpGetMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("serves stale metadata if fresh fetch fails and stale entry exists", async () => {
+        const httpGetMock = vi
+            .fn()
+            .mockReturnValueOnce(
+                of({
+                    data: {
+                        issuer: "https://as.example.org",
+                        token_endpoint: "https://as.example.org/token",
+                    },
+                }),
+            )
+            .mockReturnValueOnce(
+                throwError(() => new Error("Upstream server error")),
+            );
+
+        const service = Object.assign(
+            Object.create(Oid4vciService.prototype) as Oid4vciService,
+            {
+                httpService: { get: httpGetMock },
+                asMetadataCache: new Map(),
+                inFlightAsMetadataRequests: new Map(),
+                logger: { debug: vi.fn(), warn: vi.fn() },
+            },
+        );
+
+        // First fetch -> populates cache
+        await service["fetchAuthorizationServerMetadata"]("https://as.example.org");
+
+        // Force item in cache to be expired
+        const cachedItem = service["asMetadataCache"].get("https://as.example.org");
+        cachedItem.expiresAt = Date.now() - 1000;
+
+        // Second fetch -> fresh fetch fails, fallback to stale metadata
+        const stale = await service["fetchAuthorizationServerMetadata"](
+            "https://as.example.org",
+        );
+
+        expect(stale.issuer).toBe("https://as.example.org");
+        expect(httpGetMock).toHaveBeenCalledTimes(3);
+        expect(service["logger"].warn).toHaveBeenCalledWith(
+            expect.stringContaining("returning stale cached metadata"),
         );
     });
 });

--- a/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
@@ -6,6 +6,7 @@ import {
     Injectable,
     Logger,
     NotFoundException,
+    Optional,
 } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { InjectRepository } from "@nestjs/typeorm";
@@ -33,7 +34,7 @@ import {
 } from "@openid4vc/openid4vci";
 import type { Request } from "express";
 import { decodeJwt } from "jose";
-import { Span, TraceService } from "nestjs-otel";
+import { MetricService, Span, TraceService } from "nestjs-otel";
 import { firstValueFrom } from "rxjs";
 import { Repository } from "typeorm";
 import { v4 } from "uuid";
@@ -140,12 +141,36 @@ interface ParsedCredentialProofs {
     values: string[];
 }
 
+type CachedAsMetadata = {
+    metadata: AuthorizationServerMetadata;
+    fetchedAt: number;
+    expiresAt: number;
+};
+
+const AS_METADATA_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const AS_METADATA_STALE_TTL_MS = 60 * 60 * 1000; // 1 hour stale grace window
+
 /**
  * Service for handling OID4VCI (OpenID 4 Verifiable Credential Issuance) operations.
  */
 @Injectable()
 export class Oid4vciService {
     private readonly logger = new Logger(Oid4vciService.name);
+    private readonly asMetadataCache = new Map<string, CachedAsMetadata>();
+    private readonly inFlightAsMetadataRequests = new Map<
+        string,
+        Promise<AuthorizationServerMetadata>
+    >();
+
+    private readonly asMetadataHitsCounter;
+    private readonly asMetadataMissesCounter;
+    private readonly asMetadataStaleCounter;
+    private readonly asMetadataFetchesCounter;
+
+    clearAsMetadataCache(): void {
+        this.asMetadataCache.clear();
+        this.inFlightAsMetadataRequests.clear();
+    }
 
     constructor(
         private readonly authzService: AuthorizeService,
@@ -171,7 +196,25 @@ export class Oid4vciService {
         private readonly encryptionService: EncryptionService,
         private readonly nonceService: NonceService,
         private readonly subjectKeyService: SubjectKeyService,
-    ) {}
+        @Optional() private readonly metricService?: MetricService,
+    ) {
+        this.asMetadataHitsCounter = this.metricService?.getCounter(
+            "oid4vci_as_metadata_cache_hits_total",
+            { description: "Total hits on OID4VCI AS metadata cache" },
+        );
+        this.asMetadataMissesCounter = this.metricService?.getCounter(
+            "oid4vci_as_metadata_cache_misses_total",
+            { description: "Total misses on OID4VCI AS metadata cache" },
+        );
+        this.asMetadataStaleCounter = this.metricService?.getCounter(
+            "oid4vci_as_metadata_cache_stale_total",
+            { description: "Total stale hits on OID4VCI AS metadata cache" },
+        );
+        this.asMetadataFetchesCounter = this.metricService?.getCounter(
+            "oid4vci_as_metadata_fetches_total",
+            { description: "Total outbound AS metadata fetches" },
+        );
+    }
 
     /**
      * Get the authorization server URL for credential offers.
@@ -418,28 +461,77 @@ export class Oid4vciService {
     private async fetchAuthorizationServerMetadata(
         authServerUrl: string,
     ): Promise<AuthorizationServerMetadata> {
-        return firstValueFrom(
-            this.httpService.get(
-                `${authServerUrl}/.well-known/oauth-authorization-server`,
-            ),
-        ).then(
-            (response) => response.data,
-            async () => {
-                // Retry fetching from OIDC metadata endpoint.
-                return await firstValueFrom(
+        const now = Date.now();
+        const cached = this.asMetadataCache.get(authServerUrl);
+
+        if (cached && cached.expiresAt > now) {
+            this.asMetadataHitsCounter?.add(1, { auth_server: authServerUrl });
+            this.logger.debug(`AS metadata cache hit for ${authServerUrl}`);
+            return cached.metadata;
+        }
+
+        const inFlight = this.inFlightAsMetadataRequests.get(authServerUrl);
+        if (inFlight) {
+            this.logger.debug(
+                `Deduplicating in-flight AS metadata fetch for ${authServerUrl}`,
+            );
+            return inFlight;
+        }
+
+        this.asMetadataMissesCounter?.add(1, { auth_server: authServerUrl });
+
+        const fetchPromise = (async () => {
+            this.asMetadataFetchesCounter?.add(1, { auth_server: authServerUrl });
+            try {
+                const metadata = await firstValueFrom(
                     this.httpService.get(
-                        `${authServerUrl}/.well-known/openid-configuration`,
+                        `${authServerUrl}/.well-known/oauth-authorization-server`,
                     ),
                 ).then(
                     (response) => response.data,
-                    () => {
-                        throw new BadRequestException(
-                            "Failed to fetch authorization server metadata",
+                    async () => {
+                        // Retry fetching from OIDC metadata endpoint.
+                        return await firstValueFrom(
+                            this.httpService.get(
+                                `${authServerUrl}/.well-known/openid-configuration`,
+                            ),
+                        ).then(
+                            (response) => response.data,
+                            () => {
+                                throw new BadRequestException(
+                                    "Failed to fetch authorization server metadata",
+                                );
+                            },
                         );
                     },
                 );
-            },
-        );
+
+                this.asMetadataCache.set(authServerUrl, {
+                    metadata,
+                    fetchedAt: Date.now(),
+                    expiresAt: Date.now() + AS_METADATA_CACHE_TTL_MS,
+                });
+
+                return metadata;
+            } catch (error) {
+                if (cached && now - cached.fetchedAt <= AS_METADATA_STALE_TTL_MS) {
+                    this.asMetadataStaleCounter?.add(1, { auth_server: authServerUrl });
+                    this.logger.warn(
+                        `Failed to fetch authorization server metadata for ${authServerUrl}, returning stale cached metadata: ${String(error)}`,
+                    );
+                    return cached.metadata;
+                }
+                throw error;
+            }
+        })();
+
+        this.inFlightAsMetadataRequests.set(authServerUrl, fetchPromise);
+
+        try {
+            return await fetchPromise;
+        } finally {
+            this.inFlightAsMetadataRequests.delete(authServerUrl);
+        }
     }
 
     private async appendConfiguredAuthorizationServersInOrder(

--- a/apps/backend/src/trust/federation-trust.service.spec.ts
+++ b/apps/backend/src/trust/federation-trust.service.spec.ts
@@ -1,0 +1,170 @@
+import { HttpService } from "@nestjs/axios";
+import type { MetricService } from "nestjs-otel";
+import { of, throwError } from "rxjs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FederationTrustService } from "./federation-trust.service";
+import type { FederationTrustSource } from "./types";
+
+describe("FederationTrustService caching & deduplication", () => {
+    let service: FederationTrustService;
+    let httpService: HttpService;
+    let metricService: MetricService;
+    const addCounterMock = vi.fn();
+
+    const trustSource: FederationTrustSource = {
+        mode: "federation-only",
+        trustAnchors: [{ entityId: "https://anchor.example.org" }],
+        cacheTtlSeconds: 60,
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        httpService = {
+            get: vi.fn(),
+        } as unknown as HttpService;
+
+        metricService = {
+            getCounter: vi.fn(() => ({
+                add: addCounterMock,
+            })),
+        } as unknown as MetricService;
+
+        service = new FederationTrustService(httpService, metricService);
+    });
+
+    it("returns trusted: true immediately if entity is a configured trust anchor", async () => {
+        const result = await service.evaluateEntityTrust(
+            "https://anchor.example.org/",
+            trustSource,
+        );
+
+        expect(result).toEqual({
+            trusted: true,
+            reason: "entity is a configured federation trust anchor",
+        });
+        expect(httpService.get).not.toHaveBeenCalled();
+    });
+
+    it("fetches entity configuration and caches the evaluation result", async () => {
+        vi.spyOn(httpService, "get").mockReturnValue(
+            of({
+                data: JSON.stringify({
+                    sub: "https://entity.example.org",
+                    authority_hints: ["https://anchor.example.org"],
+                }),
+            } as any),
+        );
+
+        const result1 = await service.evaluateEntityTrust(
+            "https://entity.example.org",
+            trustSource,
+        );
+
+        expect(result1.trusted).toBe(true);
+        expect(httpService.get).toHaveBeenCalledTimes(1);
+
+        // Second call should hit the cache
+        const result2 = await service.evaluateEntityTrust(
+            "https://entity.example.org",
+            trustSource,
+        );
+
+        expect(result2.trusted).toBe(true);
+        expect(httpService.get).toHaveBeenCalledTimes(1);
+        expect(addCounterMock).toHaveBeenCalledWith(
+            1,
+            expect.objectContaining({ entity: "https://entity.example.org" }),
+        );
+    });
+
+    it("deduplicates in-flight concurrent requests for the same entity", async () => {
+        vi.spyOn(httpService, "get").mockReturnValue(
+            of({
+                data: JSON.stringify({
+                    sub: "https://entity.example.org",
+                    authority_hints: ["https://anchor.example.org"],
+                }),
+            } as any),
+        );
+
+        const [r1, r2, r3] = await Promise.all([
+            service.evaluateEntityTrust(
+                "https://entity.example.org",
+                trustSource,
+            ),
+            service.evaluateEntityTrust(
+                "https://entity.example.org",
+                trustSource,
+            ),
+            service.evaluateEntityTrust(
+                "https://entity.example.org",
+                trustSource,
+            ),
+        ]);
+
+        expect(r1.trusted).toBe(true);
+        expect(r2.trusted).toBe(true);
+        expect(r3.trusted).toBe(true);
+        expect(httpService.get).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns stale cached evaluation if re-fetch fails", async () => {
+        vi.spyOn(httpService, "get").mockReturnValueOnce(
+            of({
+                data: JSON.stringify({
+                    sub: "https://entity.example.org",
+                    authority_hints: ["https://anchor.example.org"],
+                }),
+            } as any),
+        );
+
+        // Initial fetch -> populate cache
+        await service.evaluateEntityTrust(
+            "https://entity.example.org",
+            trustSource,
+        );
+
+        // Expire the primary cache item artificially
+        const cacheKey = "https://entity.example.org::" + JSON.stringify(trustSource.trustAnchors);
+        const internalCache = (service as any).trustCache.get(cacheKey);
+        internalCache.expiresAt = Date.now() - 1000;
+
+        // Next fetch fails
+        vi.spyOn(httpService, "get").mockReturnValueOnce(
+            throwError(() => new Error("Network error")),
+        );
+
+        const staleResult = await service.evaluateEntityTrust(
+            "https://entity.example.org",
+            trustSource,
+        );
+
+        expect(staleResult.trusted).toBe(true);
+        expect(httpService.get).toHaveBeenCalledTimes(2);
+    });
+
+    it("clears cache via clearTrustCache", async () => {
+        vi.spyOn(httpService, "get").mockReturnValue(
+            of({
+                data: JSON.stringify({
+                    sub: "https://entity.example.org",
+                    authority_hints: ["https://anchor.example.org"],
+                }),
+            } as any),
+        );
+
+        await service.evaluateEntityTrust(
+            "https://entity.example.org",
+            trustSource,
+        );
+        expect(httpService.get).toHaveBeenCalledTimes(1);
+
+        service.clearTrustCache();
+
+        await service.evaluateEntityTrust(
+            "https://entity.example.org",
+            trustSource,
+        );
+        expect(httpService.get).toHaveBeenCalledTimes(2);
+    });
+});

--- a/apps/backend/src/trust/federation-trust.service.ts
+++ b/apps/backend/src/trust/federation-trust.service.ts
@@ -1,7 +1,8 @@
 import { X509Certificate } from "node:crypto";
 import { HttpService } from "@nestjs/axios";
-import { Injectable, Logger } from "@nestjs/common";
+import { Injectable, Logger, Optional } from "@nestjs/common";
 import { decodeJwt } from "jose";
+import { MetricService } from "nestjs-otel";
 import { firstValueFrom } from "rxjs";
 import { FederationTrustMode, FederationTrustSource } from "./types";
 
@@ -12,8 +13,12 @@ type FederationTrustEvaluation = {
 
 type CachedEvaluation = {
     value: FederationTrustEvaluation;
+    fetchedAt: number;
     expiresAt: number;
 };
+
+const FEDERATION_TRUST_STALE_TTL_MS = 60 * 60 * 1000; // 1 hour stale grace window
+const FEDERATION_TRUST_NEGATIVE_TTL_MS = 10 * 1000; // 10s negative cache for fetch failures
 
 type FederationEntityConfigurationPayload = {
     sub?: string;
@@ -25,8 +30,42 @@ type FederationEntityConfigurationPayload = {
 export class FederationTrustService {
     private readonly logger = new Logger(FederationTrustService.name);
     private readonly trustCache = new Map<string, CachedEvaluation>();
+    private readonly inFlightEvaluations = new Map<
+        string,
+        Promise<FederationTrustEvaluation>
+    >();
 
-    constructor(private readonly httpService: HttpService) {}
+    private readonly trustHitsCounter;
+    private readonly trustMissesCounter;
+    private readonly trustStaleCounter;
+    private readonly trustFetchesCounter;
+
+    clearTrustCache(): void {
+        this.trustCache.clear();
+        this.inFlightEvaluations.clear();
+    }
+
+    constructor(
+        private readonly httpService: HttpService,
+        @Optional() private readonly metricService?: MetricService,
+    ) {
+        this.trustHitsCounter = this.metricService?.getCounter(
+            "federation_trust_cache_hits_total",
+            { description: "Total hits on federation trust cache" },
+        );
+        this.trustMissesCounter = this.metricService?.getCounter(
+            "federation_trust_cache_misses_total",
+            { description: "Total misses on federation trust cache" },
+        );
+        this.trustStaleCounter = this.metricService?.getCounter(
+            "federation_trust_cache_stale_total",
+            { description: "Total stale hits on federation trust cache" },
+        );
+        this.trustFetchesCounter = this.metricService?.getCounter(
+            "federation_trust_fetches_total",
+            { description: "Total outbound federation entity config fetches" },
+        );
+    }
 
     getMode(source?: FederationTrustSource): FederationTrustMode {
         return source?.mode ?? "hybrid";
@@ -114,68 +153,110 @@ export class FederationTrustService {
 
         const normalizedEntityId = entityId.replace(/\/$/, "");
         const cacheKey = `${normalizedEntityId}::${JSON.stringify(source?.trustAnchors ?? [])}`;
+
+        const now = Date.now();
         const cached = this.trustCache.get(cacheKey);
-        if (cached && cached.expiresAt > Date.now()) {
+
+        if (cached && cached.expiresAt > now) {
+            this.trustHitsCounter?.add(1, { entity: normalizedEntityId });
+            this.logger.debug(
+                `Federation trust cache hit for ${normalizedEntityId}`,
+            );
             return cached.value;
         }
 
-        const anchorIds = new Set(
-            (source?.trustAnchors ?? []).map((anchor) =>
-                anchor.entityId.replace(/\/$/, ""),
-            ),
-        );
-
-        if (anchorIds.has(normalizedEntityId)) {
-            const value = {
-                trusted: true,
-                reason: "entity is a configured federation trust anchor",
-            };
-            this.setCache(cacheKey, source, value);
-            return value;
-        }
-
-        const entityConfig = await this.fetchEntityConfiguration(
-            normalizedEntityId,
-        ).catch((error: unknown) => {
-            this.logger.warn(
-                `Failed to fetch federation entity configuration for ${normalizedEntityId}: ${String(error)}`,
+        const inFlight = this.inFlightEvaluations.get(cacheKey);
+        if (inFlight) {
+            this.logger.debug(
+                `Deduplicating in-flight trust evaluation for ${normalizedEntityId}`,
             );
-            return null;
-        });
-
-        if (!entityConfig) {
-            const value = {
-                trusted: false,
-                reason: "could not fetch federation entity configuration",
-            };
-            this.setCache(cacheKey, source, value);
-            return value;
+            return inFlight;
         }
 
-        const hints = new Set(
-            (entityConfig.authority_hints ?? []).map((hint) =>
-                hint.replace(/\/$/, ""),
-            ),
-        );
+        this.trustMissesCounter?.add(1, { entity: normalizedEntityId });
 
-        const hintMatch = [...anchorIds].some((anchor) => hints.has(anchor));
-        const subjectMatches =
-            !entityConfig.sub ||
-            entityConfig.sub.replace(/\/$/, "") === normalizedEntityId;
+        const evalPromise = (async (): Promise<FederationTrustEvaluation> => {
+            const anchorIds = new Set(
+                (source?.trustAnchors ?? []).map((anchor) =>
+                    anchor.entityId.replace(/\/$/, ""),
+                ),
+            );
 
-        const trusted = subjectMatches && hintMatch;
-        const value = trusted
-            ? {
-                  trusted: true,
-                  reason: "entity authority_hints chain to configured trust anchor",
-              }
-            : {
-                  trusted: false,
-                  reason: "entity did not chain to configured trust anchor",
-              };
+            if (anchorIds.has(normalizedEntityId)) {
+                const value = {
+                    trusted: true,
+                    reason: "entity is a configured federation trust anchor",
+                };
+                this.setCache(cacheKey, source, value);
+                return value;
+            }
 
-        this.setCache(cacheKey, source, value);
-        return value;
+            this.trustFetchesCounter?.add(1, { entity: normalizedEntityId });
+
+            const entityConfig = await this.fetchEntityConfiguration(
+                normalizedEntityId,
+            ).catch((error: unknown) => {
+                this.logger.warn(
+                    `Failed to fetch federation entity configuration for ${normalizedEntityId}: ${String(error)}`,
+                );
+                return null;
+            });
+
+            if (!entityConfig) {
+                if (
+                    cached &&
+                    now - cached.fetchedAt <= FEDERATION_TRUST_STALE_TTL_MS
+                ) {
+                    this.trustStaleCounter?.add(1, {
+                        entity: normalizedEntityId,
+                    });
+                    this.logger.warn(
+                        `Failed to fetch federation entity configuration for ${normalizedEntityId}, serving stale evaluation result`,
+                    );
+                    return cached.value;
+                }
+
+                const value = {
+                    trusted: false,
+                    reason: "could not fetch federation entity configuration",
+                };
+                this.setNegativeCache(cacheKey, value);
+                return value;
+            }
+
+            const hints = new Set(
+                (entityConfig.authority_hints ?? []).map((hint) =>
+                    hint.replace(/\/$/, ""),
+                ),
+            );
+
+            const hintMatch = [...anchorIds].some((anchor) => hints.has(anchor));
+            const subjectMatches =
+                !entityConfig.sub ||
+                entityConfig.sub.replace(/\/$/, "") === normalizedEntityId;
+
+            const trusted = subjectMatches && hintMatch;
+            const value = trusted
+                ? {
+                      trusted: true,
+                      reason: "entity authority_hints chain to configured trust anchor",
+                  }
+                : {
+                      trusted: false,
+                      reason: "entity did not chain to configured trust anchor",
+                  };
+
+            this.setCache(cacheKey, source, value);
+            return value;
+        })();
+
+        this.inFlightEvaluations.set(cacheKey, evalPromise);
+
+        try {
+            return await evalPromise;
+        } finally {
+            this.inFlightEvaluations.delete(cacheKey);
+        }
     }
 
     private setCache(
@@ -186,7 +267,19 @@ export class FederationTrustService {
         const ttlMs = Math.max(5, source?.cacheTtlSeconds ?? 300) * 1000;
         this.trustCache.set(cacheKey, {
             value,
+            fetchedAt: Date.now(),
             expiresAt: Date.now() + ttlMs,
+        });
+    }
+
+    private setNegativeCache(
+        cacheKey: string,
+        value: FederationTrustEvaluation,
+    ) {
+        this.trustCache.set(cacheKey, {
+            value,
+            fetchedAt: Date.now(),
+            expiresAt: Date.now() + FEDERATION_TRUST_NEGATIVE_TTL_MS,
         });
     }
 


### PR DESCRIPTION
## 📝 Description

Introduces short-lived in-memory caching, in-flight request deduplication, and stale-last-known-good fallbacks for OpenID 4 Verifiable Credential Issuance (OID4VCI) authorization server metadata, federation trust evaluations, and Chained AS upstream OIDC discovery.

Key highlights:
- **AS Metadata Caching (`Oid4vciService`)**: Added 5-minute TTL cache and deduplication of concurrent in-flight requests when fetching external authorization server metadata, with fallback to stale metadata (1 hour window) on transient upstream failures.
- **Federation Trust Caching (`FederationTrustService`)**: Enhanced trust evaluation with in-flight promise deduplication, short negative caching (10s) for fetch failures, and stale cached trust evaluation fallback.
- **Upstream Discovery Caching (`ChainedAsService`)**: Added in-flight request deduplication and stale fallback for upstream OIDC discovery documents.
- **Observability**: Added OpenTelemetry metric counters (`MetricService`) for cache hits, misses, stale hits, and outbound fetch attempts across AS metadata, federation trust, and Chained AS discovery.

Fixes #834

## 🔄 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [x] 🧪 Test improvements
- [ ] 🏗️ Build/CI changes

## 💥 Breaking Changes (if applicable)

N/A - Non-breaking performance enhancement.

## 🧪 Testing

- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] E2E tests pass
- [x] Manual testing performed

**Test Configuration**:
- Node.js version: v22+
- OS: macOS
- Test environment: Local Vitest suite (`pnpm --filter @eudiplo/backend test`)

## 📸 Screenshots (if applicable)

N/A

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## 📋 Additional Notes

All unit tests pass cleanly, and the backend builds without errors.