### PR TITLE
fix(status-list): serialise write transactions on SQLite (#976)

### DIFF
--- a/apps/backend/src/issuer/status-list/status-list.service.spec.ts
+++ b/apps/backend/src/issuer/status-list/status-list.service.spec.ts
@@ -145,4 +145,72 @@ describe("StatusListService SQLite concurrency", () => {
         expect(current.jwt).toBeNull();
         expect(current.cwt).toBeNull();
     });
+
+    test("allocates concurrently without transaction conflicts", async () => {
+        // SQLite hands every query runner the same connection, so two
+        // transactions opened at once collide and the failure surfaces as
+        // "cannot rollback - no transaction is active". Allocation is
+        // serialised on such drivers; this asserts concurrent callers still
+        // each get a distinct index.
+        await dataSource
+            .getRepository(StatusListEntity)
+            .update(
+                { id: "list-1", tenantId: "tenant-1" },
+                { elements: [0, 0, 0, 0], stack: [0, 1, 2, 3] },
+            );
+
+        const results = await Promise.all([
+            service.createEntry(
+                { id: "session-a", tenantId: "tenant-1" } as never,
+                "config-1",
+            ),
+            service.createEntry(
+                { id: "session-b", tenantId: "tenant-1" } as never,
+                "config-1",
+            ),
+            service.createEntry(
+                { id: "session-c", tenantId: "tenant-1" } as never,
+                "config-1",
+            ),
+        ]);
+
+        const indices = results.map((result) => result.status.status_list.idx);
+        expect(new Set(indices).size).toBe(3);
+
+        const mappings = await dataSource
+            .getRepository(StatusMapping)
+            .findBy({ tenantId: "tenant-1" });
+        expect(mappings).toHaveLength(3);
+    });
+
+    test("concurrent status updates to different indices are both kept", async () => {
+        await dataSource
+            .getRepository(StatusListEntity)
+            .update(
+                { id: "list-1", tenantId: "tenant-1" },
+                { elements: [0, 0, 0, 0], stack: [0, 1, 2, 3] },
+            );
+
+        await Promise.all([
+            service
+                .updateStatus(
+                    { sessionId: "x", status: 1 } as never,
+                    "tenant-1",
+                )
+                .catch(() => undefined),
+            service
+                .updateStatus(
+                    { sessionId: "y", status: 1 } as never,
+                    "tenant-1",
+                )
+                .catch(() => undefined),
+        ]);
+
+        // The point is that concurrent update paths do not throw a driver-level
+        // transaction error; missing sessions simply update nothing.
+        const list = await dataSource
+            .getRepository(StatusListEntity)
+            .findOneByOrFail({ id: "list-1", tenantId: "tenant-1" });
+        expect(list.elements).toHaveLength(4);
+    });
 });

--- a/apps/backend/src/issuer/status-list/status-list.service.spec.ts
+++ b/apps/backend/src/issuer/status-list/status-list.service.spec.ts
@@ -33,6 +33,12 @@ describe("StatusListService SQLite concurrency", () => {
                 if (key === "PUBLIC_URL") {
                     return "https://issuer.example";
                 }
+                if (key === "STATUS_CAPACITY") {
+                    return 4;
+                }
+                if (key === "STATUS_BITS") {
+                    return 1;
+                }
                 throw new Error(`Unexpected config key: ${key}`);
             }),
         } as unknown as ConfigService;
@@ -183,34 +189,105 @@ describe("StatusListService SQLite concurrency", () => {
         expect(mappings).toHaveLength(3);
     });
 
+    test("allocates concurrently when a new list must be created", async () => {
+        Object.assign(service as object, {
+            statusListConfigService: {
+                getEffectiveConfig: vi.fn().mockResolvedValue({
+                    ttl: 300,
+                    enableAggregation: false,
+                }),
+            },
+            certService: {
+                find: vi.fn().mockResolvedValue({
+                    keyId: "status-list-key",
+                    crt: [],
+                }),
+                getLeafCertBase64: vi.fn().mockReturnValue(["certificate"]),
+            },
+            keyChainService: {
+                signJWT: vi.fn().mockResolvedValue("jwt"),
+            },
+            signStatusListCwt: vi.fn().mockResolvedValue(Uint8Array.of(1)),
+        });
+        await dataSource
+            .getRepository(StatusListEntity)
+            .update({ id: "list-1", tenantId: "tenant-1" }, { stack: [] });
+
+        const results = await Promise.all([
+            service.createEntry(
+                { id: "session-a", tenantId: "tenant-1" } as never,
+                "config-1",
+            ),
+            service.createEntry(
+                { id: "session-b", tenantId: "tenant-1" } as never,
+                "config-1",
+            ),
+        ]);
+
+        const indices = results.map((result) => result.status.status_list.idx);
+        expect(new Set(indices).size).toBe(2);
+
+        const lists = await dataSource
+            .getRepository(StatusListEntity)
+            .findBy({ tenantId: "tenant-1" });
+        expect(lists).toHaveLength(2);
+    });
+
     test("concurrent status updates to different indices are both kept", async () => {
         await dataSource
             .getRepository(StatusListEntity)
             .update(
                 { id: "list-1", tenantId: "tenant-1" },
-                { elements: [0, 0, 0, 0], stack: [0, 1, 2, 3] },
+                { elements: [0, 0, 0, 0], stack: [2, 3] },
             );
+        await dataSource.getRepository(StatusMapping).insert([
+            {
+                tenantId: "tenant-1",
+                sessionId: "x",
+                statusListId: "list-1",
+                index: 0,
+                list: "https://issuer.example/issuers/tenant-1/status-management/status-list/list-1",
+                credentialConfigurationId: "config-1",
+            },
+            {
+                tenantId: "tenant-1",
+                sessionId: "y",
+                statusListId: "list-1",
+                index: 1,
+                list: "https://issuer.example/issuers/tenant-1/status-management/status-list/list-1",
+                credentialConfigurationId: "config-1",
+            },
+        ]);
+        Object.assign(service as object, {
+            statusListConfigService: {
+                getEffectiveConfig: vi.fn().mockResolvedValue({
+                    immediateUpdate: false,
+                }),
+            },
+        });
 
         await Promise.all([
-            service
-                .updateStatus(
-                    { sessionId: "x", status: 1 } as never,
-                    "tenant-1",
-                )
-                .catch(() => undefined),
-            service
-                .updateStatus(
-                    { sessionId: "y", status: 1 } as never,
-                    "tenant-1",
-                )
-                .catch(() => undefined),
+            service.updateStatus(
+                {
+                    sessionId: "x",
+                    credentialConfigurationId: "config-1",
+                    status: 1,
+                } as never,
+                "tenant-1",
+            ),
+            service.updateStatus(
+                {
+                    sessionId: "y",
+                    credentialConfigurationId: "config-1",
+                    status: 1,
+                } as never,
+                "tenant-1",
+            ),
         ]);
 
-        // The point is that concurrent update paths do not throw a driver-level
-        // transaction error; missing sessions simply update nothing.
         const list = await dataSource
             .getRepository(StatusListEntity)
             .findOneByOrFail({ id: "list-1", tenantId: "tenant-1" });
-        expect(list.elements).toHaveLength(4);
+        expect(list.elements).toEqual([1, 1, 0, 0]);
     });
 });

--- a/apps/backend/src/issuer/status-list/status-list.service.ts
+++ b/apps/backend/src/issuer/status-list/status-list.service.ts
@@ -19,7 +19,13 @@ import {
 } from "@owf/token-status-list";
 import { X509Certificate } from "@peculiar/x509";
 import { JwtPayload } from "@sd-jwt/core";
-import { DataSource, EntityManager, IsNull, Repository } from "typeorm";
+import {
+    DataSource,
+    EntityManager,
+    IsNull,
+    type QueryRunner,
+    Repository,
+} from "typeorm";
 import { v4 } from "uuid";
 import { TenantEntity } from "../../auth/tenant/entities/tenant.entity";
 import { CertService } from "../../crypto/key/cert/cert.service";
@@ -65,6 +71,12 @@ interface AllocatedStatusEntry {
 export class StatusListService {
     private readonly logger = new Logger(StatusListService.name);
     private readonly maxRetries = 3;
+
+    /**
+     * Tail of the promise chain used to serialise write transactions when the
+     * driver cannot support concurrent ones (see {@link runSerialized}).
+     */
+    private writeQueue: Promise<unknown> = Promise.resolve();
     private readonly retryDelayMs = 100;
 
     constructor(
@@ -817,6 +829,32 @@ export class StatusListService {
     private async allocateEntries(
         options: EntryAllocationOptions,
     ): Promise<AllocatedStatusEntry[]> {
+        const { entries, shouldCreateList } = await this.runSerialized(() =>
+            this.allocateEntriesTransaction(options),
+        );
+
+        if (entries) {
+            return entries;
+        }
+
+        if (shouldCreateList) {
+            return this.createListAndAllocateEntries(options);
+        }
+
+        throw new ConflictException("No status list available for allocation");
+    }
+
+    /**
+     * The transactional part of {@link allocateEntries}, kept separate so it
+     * can be serialised as a unit. Creating a new list happens outside the
+     * transaction, so it is reported back to the caller rather than done here.
+     */
+    private async allocateEntriesTransaction(
+        options: EntryAllocationOptions,
+    ): Promise<{
+        entries?: AllocatedStatusEntry[];
+        shouldCreateList: boolean;
+    }> {
         const queryRunner = this.dataSource.createQueryRunner();
         let shouldCreateList = false;
 
@@ -840,12 +878,10 @@ export class StatusListService {
                     options,
                 );
                 await queryRunner.commitTransaction();
-                return entries;
+                return { entries, shouldCreateList: false };
             }
         } catch (error) {
-            if (queryRunner.isTransactionActive) {
-                await queryRunner.rollbackTransaction();
-            }
+            await this.safeRollback(queryRunner);
 
             if (this.isRetryableConcurrencyError(error)) {
                 throw new ConflictException(
@@ -858,11 +894,7 @@ export class StatusListService {
             await queryRunner.release();
         }
 
-        if (shouldCreateList) {
-            return this.createListAndAllocateEntries(options);
-        }
-
-        throw new ConflictException("No status list available for allocation");
+        return { shouldCreateList };
     }
 
     private async findAvailableListForAllocation(
@@ -978,6 +1010,80 @@ export class StatusListService {
     }
 
     /**
+     * Whether the configured driver can run transactions from more than one
+     * query runner at a time.
+     *
+     * TypeORM's SQLite drivers hand every query runner the same underlying
+     * connection — `connect()` returns `driver.databaseConnection` — while
+     * `isTransactionActive` and `transactionDepth` are per-runner fields. Two
+     * runners therefore each believe they are at depth 0 and both issue
+     * `BEGIN TRANSACTION` against one connection, which SQLite rejects. The
+     * failure then surfaces from the rollback in the catch block, because the
+     * per-runner flag says a transaction is active while the connection's real
+     * transaction has already been committed or rolled back by the other
+     * runner.
+     */
+    private supportsConcurrentTransactions(): boolean {
+        return this.dataSource.driver.options.type !== "better-sqlite3";
+    }
+
+    /**
+     * Run a write transaction, serialising it against other writes when the
+     * driver cannot handle concurrent transactions.
+     *
+     * On PostgreSQL this is a straight pass-through and transactions run
+     * concurrently as before. On SQLite the operations are chained so only one
+     * transaction is open at a time, which is what the single shared
+     * connection can actually support.
+     *
+     * This is deliberately not the integrity mechanism: correctness across
+     * processes and instances still rests on the version checks and the unique
+     * `(tenantId, statusListId, index)` constraint. Serialising only prevents a
+     * single process from attempting something the driver cannot do.
+     */
+    private runSerialized<T>(operation: () => Promise<T>): Promise<T> {
+        if (this.supportsConcurrentTransactions()) {
+            return operation();
+        }
+
+        const result = this.writeQueue.then(operation, operation);
+        // Keep the chain alive regardless of whether this operation settles
+        // successfully, so one failure cannot stall every later write.
+        this.writeQueue = result.then(
+            () => undefined,
+            () => undefined,
+        );
+        return result;
+    }
+
+    /**
+     * Roll back a transaction without letting the rollback itself mask the
+     * error that caused it.
+     *
+     * `queryRunner.isTransactionActive` reflects per-runner state, so it can be
+     * true while the shared connection has no open transaction. Attempting the
+     * rollback anyway raises "cannot rollback - no transaction is active",
+     * which would replace the original failure with a misleading one.
+     */
+    private async safeRollback(queryRunner: QueryRunner): Promise<void> {
+        if (!queryRunner.isTransactionActive) {
+            return;
+        }
+
+        try {
+            await queryRunner.rollbackTransaction();
+        } catch (rollbackError) {
+            this.logger.debug(
+                `Rollback skipped: ${
+                    rollbackError instanceof Error
+                        ? rollbackError.message
+                        : String(rollbackError)
+                }`,
+            );
+        }
+    }
+
+    /**
      * Helper function to introduce a delay for retry logic.
      */
     private delay(ms: number): Promise<void> {
@@ -1069,6 +1175,30 @@ export class StatusListService {
         value: number,
         tenantId: string,
     ): Promise<void> {
+        const updateCommitted = await this.runSerialized(() =>
+            this.setEntryTransaction(listId, index, value, tenantId),
+        );
+
+        if (updateCommitted) {
+            const effectiveConfig =
+                await this.statusListConfigService.getEffectiveConfig(tenantId);
+            if (effectiveConfig.immediateUpdate) {
+                await this.regenerateListTokens(tenantId, listId);
+            }
+        }
+    }
+
+    /**
+     * The transactional part of {@link setEntryWithRetry}, separated so it can
+     * be serialised as a unit. Token regeneration deliberately happens after
+     * the transaction commits, so signing never runs inside it.
+     */
+    private async setEntryTransaction(
+        listId: string,
+        index: number,
+        value: number,
+        tenantId: string,
+    ): Promise<boolean> {
         const queryRunner = this.dataSource.createQueryRunner();
         let updateCommitted = false;
 
@@ -1116,21 +1246,13 @@ export class StatusListService {
             await queryRunner.commitTransaction();
             updateCommitted = true;
         } catch (error) {
-            if (queryRunner.isTransactionActive) {
-                await queryRunner.rollbackTransaction();
-            }
+            await this.safeRollback(queryRunner);
             throw error;
         } finally {
             await queryRunner.release();
         }
 
-        if (updateCommitted) {
-            const effectiveConfig =
-                await this.statusListConfigService.getEffectiveConfig(tenantId);
-            if (effectiveConfig.immediateUpdate) {
-                await this.regenerateListTokens(tenantId, listId);
-            }
-        }
+        return updateCommitted;
     }
 
     /**

--- a/apps/backend/src/issuer/status-list/status-list.service.ts
+++ b/apps/backend/src/issuer/status-list/status-list.service.ts
@@ -829,10 +829,16 @@ export class StatusListService {
     private async allocateEntries(
         options: EntryAllocationOptions,
     ): Promise<AllocatedStatusEntry[]> {
-        const { entries, shouldCreateList } = await this.runSerialized(() =>
-            this.allocateEntriesTransaction(options),
+        return this.runSerialized(() =>
+            this.allocateEntriesSerialized(options),
         );
+    }
 
+    private async allocateEntriesSerialized(
+        options: EntryAllocationOptions,
+    ): Promise<AllocatedStatusEntry[]> {
+        const { entries, shouldCreateList } =
+            await this.allocateEntriesTransaction(options);
         if (entries) {
             return entries;
         }
@@ -986,7 +992,15 @@ export class StatusListService {
                 "Status list capacity is smaller than the requested allocation",
             );
         }
-        return this.allocateEntries(options);
+
+        const { entries } = await this.allocateEntriesTransaction(options);
+        if (!entries) {
+            throw new ConflictException(
+                "No status list available after creating a new list",
+            );
+        }
+
+        return entries;
     }
 
     private async retryOnConcurrency<T>(


### PR DESCRIPTION
## 📝 Description

Fixes #976 , concurrent status list allocation failing on SQLite with `SqliteError: cannot rollback - no transaction is active`.

### Root cause

TypeORM's SQLite drivers hand every query runner the same underlying connection, `AbstractSqliteQueryRunner.connect()` returns `driver.databaseConnection`, and the source comments note that "sqlite do not support multiple connections thus query runners". But `isTransactionActive` and `transactionDepth` are per-query-runner fields.

So two runners each see `transactionDepth === 0` and both issue `BEGIN TRANSACTION` against the one connection, which SQLite rejects. The failure then surfaces from the rollback in the `catch` block: the per-runner flag still says a transaction is active while the connection's real transaction has already been committed or rolled back by the other runner, so `ROLLBACK` has nothing to roll back, and that error replaces the original one.

The existing `if (queryRunner.isTransactionActive)` guard can't help here, because it asks a per-runner flag about connection-wide state.

### Changes

**Serialise write transactions on drivers that can't run them concurrently.** `runSerialized()` chains transactional operations when the driver is SQLite, and is a straight pass-through on PostgreSQL so nothing changes there. The two transactional bodies (`allocateEntriesTransaction`, `setEntryTransaction`) are split out from their callers so they can be serialised as whole units, with list creation and token regeneration staying outside the transaction as before.

This is deliberately not the integrity mechanism. Correctness across processes and instances still rests on the version checks and the unique `(tenantId, statusListId, index)` constraint from #950  , serialising only stops a single process attempting something the driver cannot do, which addresses the "must not rely solely on an in-process mutex" requirement from #910.

**Make rollback non-masking.** `safeRollback()` swallows and debug-logs a rollback failure instead of letting it replace the error that caused it. Even with serialisation this matters: a driver-level rollback error should never be what the caller sees.

## 🧪 Testing

Two tests added to the existing SQLite concurrency suite:

- `allocates concurrently without transaction conflicts` - three concurrent `createEntry` calls return three distinct indices and persist three mappings. This fails on `main` with the reported error, and fails again if `runSerialized` is stubbed out, so it genuinely covers the fix.
- `concurrent status updates to different indices are both kept` - concurrent update paths no longer raise driver-level transaction errors.

`pnpm --filter @eudiplo/backend test` - 12 passed. Typecheck and Biome clean.

## 📋 Additional notes

Only SQLite behaviour changes; the PostgreSQL path is untouched. Postgres concurrency tests are still worth adding separately (testcontainers are already a devDependency), but felt out of scope here.