### PR TITLE
Fix credential config editor validation

### DIFF
--- a/apps/backend/src/platform/config-import/config-import.service.ts
+++ b/apps/backend/src/platform/config-import/config-import.service.ts
@@ -144,7 +144,9 @@ export class ConfigImportService {
                     );
 
                     if (!validationResult.isValid) {
-                        continue; // Skip invalid config
+                        throw new Error(
+                            `Validation failed for ${options.resourceType} ${file}`,
+                        );
                     }
 
                     data = validationResult.data as T;
@@ -312,7 +314,9 @@ export class ConfigImportService {
                         );
 
                         if (!validationResult.isValid) {
-                            continue; // Skip invalid config
+                            throw new Error(
+                                `Validation failed for ${options.resourceType} ${file}`,
+                            );
                         }
 
                         data = validationResult.data as T;

--- a/apps/cli/templates/demo-config/issuance/credentials/pid-key.json
+++ b/apps/cli/templates/demo-config/issuance/credentials/pid-key.json
@@ -298,7 +298,7 @@
       "children": [
         {
           "path": [
-            0
+            null
           ],
           "type": "string",
           "defaultValue": "DE",

--- a/apps/cli/templates/demo-config/issuance/credentials/pid.json
+++ b/apps/cli/templates/demo-config/issuance/credentials/pid.json
@@ -398,7 +398,7 @@
       "children": [
         {
           "path": [
-            0
+            null
           ],
           "type": "string",
           "defaultValue": "DE",

--- a/apps/client/src/app/app.config.ts
+++ b/apps/client/src/app/app.config.ts
@@ -29,6 +29,10 @@ const monacoBaseUrl = new URL(
   new URL(baseHref, document.location.origin)
 ).toString();
 
+function normalizeLocalSchemaUri(uri: string): string {
+  return uri.startsWith('./') ? `a://b/${uri.slice(2)}` : uri;
+}
+
 const transactionDataArraySchema = {
   uri: 'https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TransactionDataArray.schema.json',
   fileMatch: ['a://b/TransactionDataArray*.schema.json'],
@@ -52,7 +56,11 @@ function toEditorFriendlySchema(node: any): any {
 
   const out: Record<string, any> = {};
   for (const [key, value] of Object.entries(node)) {
-    out[key] = toEditorFriendlySchema(value);
+    if ((key === '$id' || key === '$ref') && typeof value === 'string') {
+      out[key] = normalizeLocalSchemaUri(value);
+    } else {
+      out[key] = toEditorFriendlySchema(value);
+    }
   }
 
   // Monaco JSON suggestions are more stable with anyOf than oneOf for
@@ -153,10 +161,13 @@ function onMonacoLoad() {
 
   const editorSchemas = schemas.map((entry) => ({
     ...entry,
+    uri: normalizeLocalSchemaUri(entry.uri),
     fileMatch:
       entry.uri === './TransactionData.schema.json'
         ? ['a://b/TransactionData-*.schema.json']
-        : entry.fileMatch,
+        : entry.uri === './CredentialConfig.schema.json'
+          ? ['a://b/CredentialConfig-*.schema.json']
+          : entry.fileMatch,
     schema: toEditorFriendlySchema(entry.schema),
   }));
 

--- a/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.html
+++ b/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.html
@@ -901,6 +901,15 @@
               </mat-card-subtitle>
             </mat-card-header>
             <mat-card-content>
+              <p class="fields-help">
+                For nested objects and arrays, see the
+                <a
+                  href="https://docs.eudiplo.dev/issuance/credential-configuration#configuring-fields"
+                  target="_blank"
+                  rel="noopener"
+                  >See the field structure guide</a
+                >
+              </p>
               <mat-accordion formArrayName="fields" multi>
                 @for (field of fields.controls; track $index; let i = $index) {
                   <mat-expansion-panel [formGroupName]="i">

--- a/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.ts
+++ b/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.ts
@@ -945,9 +945,10 @@ export class CredentialConfigCreateComponent implements OnInit {
 
     formValue.fields = this.buildFieldsPayload(formValue.fields || []);
 
-    // Convert empty strings to null to clear optional fields (for PATCH semantics)
-    formValue.keyChainId = formValue.keyChainId || null;
-    formValue.scope = formValue.scope || null;
+    // Omit empty optional strings so they remain valid against the config schema.
+    if (!formValue.keyChainId?.trim()) {
+      delete formValue.keyChainId;
+    }
 
     // SD-JWT specific fields (only include if SD-JWT format)
     if (isMdoc) {
@@ -1002,6 +1003,7 @@ export class CredentialConfigCreateComponent implements OnInit {
     delete formValue.vctString;
     delete formValue.format;
     delete formValue.docType;
+    delete formValue.scope;
     delete formValue.namespace;
     delete formValue.keyAttestationEnabled;
     delete formValue.keyStorageTypes;
@@ -1134,7 +1136,8 @@ export class CredentialConfigCreateComponent implements OnInit {
 
     if (parentType === 'array' && childPath.length > 0) {
       if (childPath[0] === null || typeof childPath[0] === 'number') {
-        return [...parentPath, ...childPath.slice(1)];
+        // Keep a wildcard marker so the array item's path stays distinct from its parent's.
+        return [...parentPath, null, ...childPath.slice(1)];
       }
     }
 

--- a/apps/client/src/app/issuance/credential-config/credential-config-create/json-view-dialog/json-view-dialog.component.scss
+++ b/apps/client/src/app/issuance/credential-config/credential-config-create/json-view-dialog/json-view-dialog.component.scss
@@ -1,10 +1,15 @@
 mat-dialog-content {
-  min-width: 800px;
+  box-sizing: border-box;
+  width: min(1200px, 90vw);
+  min-width: min(800px, 90vw);
   min-height: 800px;
   max-width: 90vw;
   max-height: 80vh;
+  overflow-x: hidden;
 }
 ::ng-deep ngx-monaco-editor {
   height: 800px !important;
-  width: 1200px;
+  display: block;
+  width: 100%;
+  min-width: 0;
 }

--- a/apps/client/src/app/utils/editor/editor.component.html
+++ b/apps/client/src/app/utils/editor/editor.component.html
@@ -4,6 +4,7 @@
       <ngx-monaco-editor
         [options]="themedEditorOptions"
         [(ngModel)]="value"
+        [ngModelOptions]="{ standalone: true }"
         [model]="model"
         (onInit)="onEditorInit($event)"
         (ngModelChange)="handleChange($event)"

--- a/apps/client/src/app/utils/editor/editor.component.ts
+++ b/apps/client/src/app/utils/editor/editor.component.ts
@@ -63,7 +63,7 @@ export class EditorComponent implements ControlValueAccessor, Validator, OnChang
   value = '';
   disabled = false;
 
-  private readonly ajv = new Ajv();
+  private readonly ajv = new Ajv({ allowUnionTypes: true });
   private validateFn?: ValidateFunction;
   private schemaValidationError?: string;
   private readonly instanceId = ++editorInstanceCounter;
@@ -127,7 +127,7 @@ export class EditorComponent implements ControlValueAccessor, Validator, OnChang
     }
 
     if (this.validateFn && !this.validateFn(parsed)) {
-      const msg = this.ajv.errorsText(this.validateFn.errors || undefined, { separator: ' | ' });
+      const msg = this.formatValidationErrors(this.validateFn.errors);
       return { invalidSchema: msg || 'Schema validation failed' };
     }
 
@@ -139,6 +139,28 @@ export class EditorComponent implements ControlValueAccessor, Validator, OnChang
   }
   registerOnValidatorChange?(fn: () => void): void {
     this._validatorChange = fn;
+  }
+
+  /**
+   * Turn Ajv errors into readable messages, naming the offending property
+   * instead of Ajv's generic root "data" placeholder.
+   */
+  private formatValidationErrors(errors: ValidateFunction['errors']): string {
+    if (!errors?.length) {
+      return '';
+    }
+
+    return errors
+      .map((error) => {
+        const path = error.instancePath?.replace(/^\//, '').replaceAll('/', '.') || 'root';
+        if (error.keyword === 'additionalProperty' || error.keyword === 'additionalProperties') {
+          const extra = (error.params as { additionalProperty?: string })?.additionalProperty;
+          const suffix = extra ? ` "${extra}"` : '';
+          return `${path}: must NOT have additional property${suffix}`;
+        }
+        return `${path} ${error.message}`;
+      })
+      .join(' | ');
   }
 
   // Handlers

--- a/apps/docs/docs/issuance/credential-configuration.md
+++ b/apps/docs/docs/issuance/credential-configuration.md
@@ -64,7 +64,21 @@ Nested child paths can be defined in two ways:
 - relative to the parent path (recommended), or
 - as a full absolute path (also supported).
 
-For arrays, use numeric child path segments such as `[0]` to describe item entries.
+For arrays, use a wildcard item path. In the form editor, write `*` (for example
+`nationalities.*`). In JSON configuration, the equivalent path segment is `null`:
+
+```json
+{
+    "path": ["nationalities"],
+    "type": "array",
+    "children": [
+        {
+            "path": [null],
+            "type": "string"
+        }
+    ]
+}
+```
 
 :::info[Claims Priority System]
 EUDIPLO supports multiple ways to provide claims (configuration-level and offer-level), with a priority system that determines which claims are used. For a complete explanation of the claims priority order and when to use each method, see [Claims](claims.md).
@@ -129,7 +143,7 @@ You can define defaults directly in each field using `defaultValue`:
             },
             "children": [
                 {
-                    "path": [0],
+                    "path": [null],
                     "type": "string",
                     "defaultValue": "DE",
                     "disclosable": false
@@ -153,6 +167,21 @@ Use `children` when you want to model grouped structures like `address`, `age_eq
 - Parent node: define `path` and `type` (`object` or `array`)
 - Child nodes: define claim fields under `children[]`
 - Child paths: prefer relative paths (for example `"path": ["street_address"]` under parent `"path": ["address"]`)
+
+#### Web Client Field Editor
+
+The web client displays fields as a flat list, so use dot-separated paths to represent the
+nested structure:
+
+- Add the container first, with type `object` or `array`.
+- Add each object property using its full path, such as `address.locality`.
+- Add an array item using `*`, such as `nationalities.*`.
+- For deeper structures, use **JSON View** and the nested `children[]` form shown above. Array
+  item paths use `null` in JSON, not `0`, because the item represents any array element.
+
+For example, the form editor entries `address` (`object`), `address.locality` (`string`), and
+`nationalities` (`array`), `nationalities.*` (`string`) produce nested object and array fields
+when saved.
 
 This structure improves readability in config files and enables grouped rendering in form-based UIs.
 

--- a/assets/config/demo/issuance/credentials/pid-key.json
+++ b/assets/config/demo/issuance/credentials/pid-key.json
@@ -298,7 +298,7 @@
       "children": [
         {
           "path": [
-            0
+            null
           ],
           "type": "string",
           "defaultValue": "DE",

--- a/assets/config/demo/issuance/credentials/pid.json
+++ b/assets/config/demo/issuance/credentials/pid.json
@@ -398,7 +398,7 @@
       "children": [
         {
           "path": [
-            0
+            null
           ],
           "type": "string",
           "defaultValue": "DE",


### PR DESCRIPTION
## 📝 Description

Fixes credential configuration editor validation and nested field authoring issues. The client now builds payloads that match the credential schema, resolves bundled Monaco schema references locally, and documents object/array field setup clearly.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change)
- [x] 📚 Documentation update
- [ ] 💥 Breaking change
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements
- [ ] 🏗️ Build/CI changes

## 💥 Breaking Changes (if applicable)

None.

## 🧪 Testing

- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] E2E tests pass
- [ ] Manual testing performed

**Validation performed:**

- Angular client development build passes.
- Documentation Markdown lint passes.
- Repository commit hooks pass formatting, linting, and Knip.
- Updated demo credential JSON files parse successfully.

## 📸 Screenshots (if applicable)

Not applicable.

## ✔️ Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing validation checks pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

## 📋 Additional Notes

Main changes:

- Prevent invalid configs from reaching persistence during config import.
- Keep optional credential fields schema-valid by omitting empty values where appropriate.
- Normalize local Monaco `$ref` and `$id` URIs and avoid overlapping credential schema matches.
- Constrain the Monaco JSON dialog so editor tooltips do not resize it.
- Clarify nested object/array fields in the UI and documentation; update demo array child paths from `[0]` to `[null]`.

An unrelated local modification to `assets/config/demo/clients/test.json` was intentionally left out of this PR.