### PR TITLE
fix: Update documentation links to docs.eudiplo.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,10 @@ For production authentication setup, see [Authentication](https://docs.eudiplo.d
 Use the current documentation:
 
 - 🚀 **Documentation**: [https://docs.eudiplo.dev/](https://docs.eudiplo.dev/)
-- **Legacy documentation**: [https://openwallet-foundation.github.io/eudiplo/docs/latest/](https://openwallet-foundation.github.io/eudiplo/docs/latest/)
+- **Legacy documentation**: [https://docs.eudiplo.dev/](https://docs.eudiplo.dev/)
 
 The current documentation reflects the active release. For older releases,
-use the [legacy documentation archive](https://openwallet-foundation.github.io/eudiplo/docs/latest/).
+use the [legacy documentation archive](https://docs.eudiplo.dev/).
 
 **Key sections:**
 

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -143,7 +143,7 @@ export class AuthService {
             scopes_supported: ["openid"],
             claims_supported: ["iss", "sub", "aud", "exp", "iat"],
             service_documentation:
-                "https://openwallet-foundation.github.io/eudiplo/docs/latest/",
+                "https://docs.eudiplo.dev/",
         };
     }
 }

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -149,7 +149,7 @@ async function bootstrap() {
         )
         .setExternalDoc(
             "Documentation",
-            "https://openwallet-foundation.github.io/eudiplo/docs/latest/",
+            "https://docs.eudiplo.dev/",
         )
         .setOpenAPIVersion("3.1.0")
         .setVersion(process.env.VERSION ?? "main");
@@ -193,7 +193,7 @@ async function bootstrap() {
         )
         .setExternalDoc(
             "Documentation",
-            "https://openwallet-foundation.github.io/eudiplo/docs/latest/",
+            "https://docs.eudiplo.dev/",
         )
         .setOpenAPIVersion("3.1.0")
         .setVersion(process.env.VERSION ?? "main")
@@ -301,7 +301,7 @@ async function bootstrap() {
             logger.log(`   → Management:   ${baseUrl}/api/docs`);
             logger.log(`   → Protocol:     ${baseUrl}/docs`);
             logger.log(
-                `   → Full Docs:    https://openwallet-foundation.github.io/eudiplo/docs/latest/`,
+                `   → Full Docs:    https://docs.eudiplo.dev/`,
             );
             logger.log("");
             logger.log("🏥 Health Check:");

--- a/apps/cli/src/runtime.ts
+++ b/apps/cli/src/runtime.ts
@@ -54,7 +54,7 @@ export function createProgram(
         .helpCommand(true)
         .addHelpText(
             "afterAll",
-            "\nFor more information, see https://openwallet-foundation.github.io/eudiplo/docs/latest/getting-started/cli/",
+            "\nFor more information, see https://docs.eudiplo.dev/getting-started/quick-start",
         );
 
     program.addCommand(createDemoCommand(context, setExitCode));

--- a/apps/cli/templates/docker-compose.yml
+++ b/apps/cli/templates/docker-compose.yml
@@ -7,7 +7,7 @@
 #   docker compose --profile postgres --profile s3 up  # Custom components
 #
 # For more information, see the documentation:
-# https://openwallet-foundation.github.io/eudiplo/docs/latest/deployment/docker-compose/
+# https://docs.eudiplo.dev/deployment/docker-compose/
 
 services:
   # =============================================================================

--- a/apps/client/src/app/login/login.component.html
+++ b/apps/client/src/app/login/login.component.html
@@ -152,7 +152,7 @@
 
             <a
               mat-button
-              href="https://openwallet-foundation.github.io/eudiplo/main/"
+              href="https://eudiplo.dev/main/"
               target="_blank"
               rel="noopener"
             >

--- a/apps/client/src/app/tenants/client/client-create/client-create.component.html
+++ b/apps/client/src/app/tenants/client/client-create/client-create.component.html
@@ -54,7 +54,7 @@
           <mat-hint>
             Select one or more roles.
             <a
-              href="https://openwallet-foundation.github.io/eudiplo/docs/latest/api/authentication/#protected-endpoints"
+              href="https://docs.eudiplo.dev/api/authentication/#protected-endpoints"
               target="_blank"
               rel="noopener"
               >Learn about roles</a

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -162,7 +162,7 @@ const config: Config = {
           position: 'right',
         },
         {
-          href: 'https://openwallet-foundation.github.io/eudiplo/docs/latest/',
+          href: 'https://docs.eudiplo.dev/',
           label: 'Legacy Docs',
           position: 'right',
         },

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -3,7 +3,7 @@
 This directory contains deployment configurations for EUDIPLO with multiple profiles to match your infrastructure needs.
 
 **📖 For comprehensive deployment documentation, visit:**  
-**[https://openwallet-foundation.github.io/eudiplo/docs/latest/deployment/](https://openwallet-foundation.github.io/eudiplo/docs/latest/deployment/)**
+**[https://docs.eudiplo.dev/deployment/](https://docs.eudiplo.dev/deployment/)**
 
 ## Deployment Options
 
@@ -66,9 +66,9 @@ deployment/
 
 | Deployment         | Path                    | Documentation                                                                                                  | Use Case      |
 | ------------------ | ----------------------- | -------------------------------------------------------------------------------------------------------------- | ------------- |
-| **Quick Start**    | `../docker-compose.yml` | [Docker Compose Guide](https://openwallet-foundation.github.io/eudiplo/docs/latest/deployment/docker-compose/) | Quick testing |
-| **Docker Compose** | `docker-compose/`       | [Docker Compose Guide](https://openwallet-foundation.github.io/eudiplo/docs/latest/deployment/docker-compose/) | Development   |
-| **Kubernetes**     | `k8s/`                  | [Kubernetes Guide](https://openwallet-foundation.github.io/eudiplo/docs/latest/deployment/kubernetes/)         | Production    |
+| **Quick Start**    | `../docker-compose.yml` | [Docker Compose Guide](https://docs.eudiplo.dev/deployment/docker-compose/) | Quick testing |
+| **Docker Compose** | `docker-compose/`       | [Docker Compose Guide](https://docs.eudiplo.dev/deployment/docker-compose/) | Development   |
+| **Kubernetes**     | `k8s/`                  | [Kubernetes Guide](https://docs.eudiplo.dev/deployment/kubernetes/)         | Production    |
 
 ## Service Access
 
@@ -84,6 +84,6 @@ After deployment, access the services at:
 
 ## Support
 
-- **Documentation:** [https://openwallet-foundation.github.io/eudiplo/docs/latest/](https://openwallet-foundation.github.io/eudiplo/docs/latest/)
+- **Documentation:** [https://docs.eudiplo.dev/](https://docs.eudiplo.dev/)
 - **Issues:** [GitHub Issues](https://github.com/openwallet-foundation/eudiplo/issues)
 - **Community:** [Discord](https://discord.gg/58ys8XfXDu)

--- a/deployment/docker-compose/.env.full.example
+++ b/deployment/docker-compose/.env.full.example
@@ -107,7 +107,7 @@ MINIO_ROOT_PASSWORD=changeme-strong-password
 # =============================================================================
 # Telemetry (optional)
 # Enable OpenTelemetry export to a collector for metrics, traces, and logs.
-# See: https://openwallet-foundation.github.io/eudiplo/docs/latest/getting-started/monitor/
+# See: https://docs.eudiplo.dev/getting-started/monitor/
 # =============================================================================
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
 # OTEL_SDK_DISABLED=false
@@ -122,7 +122,7 @@ MINIO_ROOT_PASSWORD=changeme-strong-password
 # =============================================================================
 # Client: Subpath Configuration (optional)
 # Uncomment to serve the client from a reverse proxy subpath.
-# See: https://openwallet-foundation.github.io/eudiplo/docs/latest/deployment/tls/#serving-the-client-from-a-subpath
+# See: https://docs.eudiplo.dev/deployment/tls/#serving-the-client-from-a-subpath
 # =============================================================================
 # CLIENT_BASE_HREF=/eudiplo-client/
 

--- a/deployment/docker-compose/.env.minimal.example
+++ b/deployment/docker-compose/.env.minimal.example
@@ -65,6 +65,6 @@ LOCAL_STORAGE_DIR=/app/uploads
 # =============================================================================
 # Client: Subpath Configuration (optional)
 # Uncomment to serve the client from a reverse proxy subpath.
-# See: https://openwallet-foundation.github.io/eudiplo/docs/latest/deployment/tls/#serving-the-client-from-a-subpath
+# See: https://docs.eudiplo.dev/deployment/tls/#serving-the-client-from-a-subpath
 # =============================================================================
 # CLIENT_BASE_HREF=/eudiplo-client/

--- a/deployment/docker-compose/.env.standard.example
+++ b/deployment/docker-compose/.env.standard.example
@@ -96,7 +96,7 @@ MINIO_ROOT_PASSWORD=minioadmin
 # =============================================================================
 # Telemetry (optional)
 # Enable OpenTelemetry export to a collector for metrics, traces, and logs.
-# See: https://openwallet-foundation.github.io/eudiplo/docs/latest/getting-started/monitor/
+# See: https://docs.eudiplo.dev/getting-started/monitor/
 # =============================================================================
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
 # OTEL_SDK_DISABLED=false
@@ -111,6 +111,6 @@ MINIO_ROOT_PASSWORD=minioadmin
 # =============================================================================
 # Client: Subpath Configuration (optional)
 # Uncomment to serve the client from a reverse proxy subpath.
-# See: https://openwallet-foundation.github.io/eudiplo/docs/latest/deployment/tls/#serving-the-client-from-a-subpath
+# See: https://docs.eudiplo.dev/deployment/tls/#serving-the-client-from-a-subpath
 # =============================================================================
 # CLIENT_BASE_HREF=/eudiplo-client/

--- a/deployment/docker-compose/README.md
+++ b/deployment/docker-compose/README.md
@@ -172,4 +172,4 @@ After deployment, access the services at:
 4. **Set up TLS/HTTPS** via reverse proxy
 5. **Configure backup strategies** for PostgreSQL and MinIO
 
-For more details, see the [full documentation](https://openwallet-foundation.github.io/eudiplo/docs/latest/deployment/docker-compose/).
+For more details, see the [full documentation](https://docs.eudiplo.dev/deployment/docker-compose/).

--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -7,7 +7,7 @@
 #   docker compose --profile postgres --profile s3 up  # Custom components
 #
 # For more information, see the documentation:
-# https://openwallet-foundation.github.io/eudiplo/docs/latest/deployment/docker-compose/
+# https://docs.eudiplo.dev/deployment/docker-compose/
 
 services:
   # =============================================================================

--- a/deployment/k8s/README.md
+++ b/deployment/k8s/README.md
@@ -2,7 +2,7 @@
 
 This directory contains Kubernetes manifests for EUDIPLO using Kustomize for flexible, composable deployments.
 
-📚 **Full documentation:** [https://openwallet-foundation.github.io/eudiplo/docs/latest/deployment/kubernetes/](https://openwallet-foundation.github.io/eudiplo/docs/latest/deployment/kubernetes/)
+📚 **Full documentation:** [https://docs.eudiplo.dev/deployment/kubernetes/](https://docs.eudiplo.dev/deployment/kubernetes/)
 
 ## Directory Structure
 
@@ -153,4 +153,4 @@ The full overlay deploys Vault in development mode and creates its encryption ke
 automatically. Use an externally managed, initialized Vault instance with a
 restricted token for production.
 
-👉 **[Read the full documentation](https://openwallet-foundation.github.io/eudiplo/docs/latest/deployment/kubernetes/)**
+👉 **[Read the full documentation](https://docs.eudiplo.dev/deployment/kubernetes/)**


### PR DESCRIPTION
## 📝 Description

In #959, the documentation was modernized. It appears that the documentation domain changed as part of that work, but the references were not updated accordingly.

The old URLs now redirect to the documentation homepage instead of the referenced documentation page or chapter.

This PR updates those references to use the correct domain.

## 🔄 Type of Change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)
* [x] 📚 Documentation update

## 💥 Breaking Changes

Not applicable.

## 🧪 Testing

Not applicable. These changes only update documentation links.

## 📸 Screenshots

Not applicable.

## ✔️ Checklist

* [x] My code follows the code style of this project
* [x] I have performed a self-review of my own changes
* [x] I have made the corresponding documentation changes
* [x] My changes generate no new warnings

## 📋 Additional Notes

There is also a link to the legacy documentation in `apps/docs/docs/contributing/documentation.md:111`.

That link is currently broken, and I am not sure what the correct replacement URL should be, so it has not been changed as part of this PR.